### PR TITLE
Fix/penny animation

### DIFF
--- a/NpcAdventure/PurrplingMod.cs
+++ b/NpcAdventure/PurrplingMod.cs
@@ -21,6 +21,7 @@ namespace PurrplingMod
         private DialogueDriver DialogueDriver { get; set; }
         private HintDriver HintDriver { get; set; }
         private StuffDriver StuffDriver { get; set; }
+        internal static PurrplingMod Mod { get; private set; }
 
         /// <summary>The mod entry point, called after the mod is first loaded.</summary>
         /// <param name="helper">Provides simplified APIs for writing mods.</param>
@@ -37,6 +38,8 @@ namespace PurrplingMod
             this.StuffDriver = new StuffDriver(helper.Events, helper.Data, this.Monitor);
             this.contentLoader = new ContentLoader(helper.Content, helper.DirectoryPath, "assets", this.Monitor);
             this.companionManager = new CompanionManager(this.DialogueDriver, this.HintDriver, this.Monitor);
+
+            PurrplingMod.Mod = this;
         }
 
         private void GameLoop_GameLaunched(object sender, GameLaunchedEventArgs e)

--- a/NpcAdventure/StateMachine/State/AvailableState.cs
+++ b/NpcAdventure/StateMachine/State/AvailableState.cs
@@ -57,8 +57,11 @@ namespace PurrplingMod.StateMachine.State
             {
                 if (answer == "Yes")
                 {
-                    this.StateMachine.Companion.Halt();
-                    this.StateMachine.Companion.facePlayer(leader);
+                    if (!this.StateMachine.Companion.doingEndOfRouteAnimation.Value)
+                    {
+                        this.StateMachine.Companion.Halt();
+                        this.StateMachine.Companion.facePlayer(leader);
+                    }
                     this.ReactOnAnswer(this.StateMachine.Companion, leader);
                 }
             }, null);

--- a/NpcAdventure/StateMachine/State/RecruitedState.cs
+++ b/NpcAdventure/StateMachine/State/RecruitedState.cs
@@ -10,7 +10,6 @@ using Microsoft.Xna.Framework;
 using System.Reflection;
 using StardewValley.Menus;
 using StardewValley.Objects;
-using PurrplingMod.Model;
 using System;
 using PurrplingMod.Buffs;
 using StardewModdingAPI;
@@ -36,6 +35,9 @@ namespace PurrplingMod.StateMachine.State
         {
             this.ai = new AI_StateMachine(this.StateMachine.Companion, this.StateMachine.CompanionManager.Farmer, this.Events, this.StateMachine.Monitor);
 
+            if (this.StateMachine.Companion.doingEndOfRouteAnimation.Value)
+                this.FinishScheduleAnimation();
+
             this.StateMachine.Companion.faceTowardFarmerTimer = 0;
             this.StateMachine.Companion.movementPause = 0;
             this.StateMachine.Companion.followSchedule = false;
@@ -59,6 +61,21 @@ namespace PurrplingMod.StateMachine.State
             this.CanCreateDialogue = true;
 
             this.ai.Setup();
+        }
+
+        /// <summary>
+        /// Animate last sequence of current schedule animation
+        /// </summary>
+        private void FinishScheduleAnimation()
+        {
+            // Prevent animation freeze glitch
+            this.StateMachine.Companion.Sprite.standAndFaceDirection(this.StateMachine.Companion.FacingDirection);
+
+            // And then play finish animation "end of route animation" when companion is recruited
+            // Must be called via reflection, because they are private members of NPC class
+            PurrplingMod.Mod.Helper.Reflection.GetMethod(this.StateMachine.Companion, "finishEndOfRouteAnimation").Invoke();
+            this.StateMachine.Companion.doingEndOfRouteAnimation.Value = false;
+            PurrplingMod.Mod.Helper.Reflection.GetField<Boolean>(this.StateMachine.Companion, "currentlyDoingEndOfRouteAnimation").SetValue(false);
         }
 
         public override void Exit()


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Content updates (new dialogues added or some string edited and etc)
- [ ] My change requires a change to the documentation.
- [ ] **Merge ASAP**
- [ ] Merge before *enumerated issues or other PRs numbers*
- [ ] Merge after *enumerated issues or other PRs numbers*
- [x] PR #17 need rebase

## Description

This PR fixes a bug animation with Peny. Takes effect to all `endOfRoute` animations on all NPCs, when NPC is recruited or NPC rejected. 

Improves play end or route animation after NPC was recruited. If NPC playing animation of their schedule and we recruit that NPC, then NPC plays the same animation like NPC's schedule changes and NPC go to new way to new endpoint.

![penyanimok](https://user-images.githubusercontent.com/4710267/67713900-089fa880-f9c7-11e9-8838-8be18da69c64.gif)

## How to test
Try to recruit a NPC who is in schedule animation (like peny on gif above).
- Case1: NPC rejected - **No bad animation or animation frame affected NPC**
- Case2: NPC accepted - **Schedule canceled, animation played without defects and companion recruited**

No other defects affected.

## Checklist

**Please check if the PR fulfills these requirements**
- [x] Changes was tested and passed

## Other information
---
<!-- Related issues, see https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords#about-issue-references
  For example:
    - Closes #1, fixes #2
    - Requires #5
    - Is required for #6
    - ... and some others
-->
closes #19 