### PR TITLE
Avoid say hi to monster and return to farm house when companion recruited

### DIFF
--- a/NpcAdventure/NpcAdventure.csproj
+++ b/NpcAdventure/NpcAdventure.csproj
@@ -96,6 +96,8 @@
     <Compile Include="Model\CompanionMetaData.cs" />
     <Compile Include="Objects\Package.cs" />
     <Compile Include="Patches\GameLocationDrawPatch.cs" />
+    <Compile Include="Patches\CompanionSayHiPatch.cs" />
+    <Compile Include="Patches\SpouseReturnHomePatch.cs" />
     <Compile Include="StateMachine\StateFeatures\IRequestedDialogueCreator.cs" />
     <Compile Include="StateMachine\StateFeatures\IDialogueDetector.cs" />
     <Compile Include="StateMachine\StateFeatures\ICompanionIntegrator.cs" />

--- a/NpcAdventure/NpcAdventureMod.cs
+++ b/NpcAdventure/NpcAdventureMod.cs
@@ -58,12 +58,10 @@ namespace NpcAdventure
             
             //Harmony
             HarmonyInstance harmony = HarmonyInstance.Create("Purrplingcat.NpcAdventure");
-            harmony.Patch(
-                original: AccessTools.Method(typeof(GameLocation), "draw"),
-                postfix: new HarmonyMethod(typeof(Patches.GameLocationDrawPatch), nameof(Patches.GameLocationDrawPatch.Postfix))
-            );
-
-            Patches.GameLocationDrawPatch.Setup(this.SpecialEvents);
+            
+            Patches.SpouseReturnHomePatch.Setup(harmony);
+            Patches.CompanionSayHiPatch.Setup(harmony, this.companionManager);
+            Patches.GameLocationDrawPatch.Setup(harmony, this.SpecialEvents);
         }
 
         private void Specialized_LoadStageChanged(object sender, LoadStageChangedEventArgs e)
@@ -117,6 +115,9 @@ namespace NpcAdventure
                 return;
             this.companionManager.UninitializeCompanions();
             this.contentLoader.InvalidateCache();
+
+            // Clean data in patches
+            Patches.SpouseReturnHomePatch.recruitedSpouses.Clear();
         }
 
         private void GameLoop_SaveLoaded(object sender, StardewModdingAPI.Events.SaveLoadedEventArgs e)

--- a/NpcAdventure/Patches/CompanionSayHiPatch.cs
+++ b/NpcAdventure/Patches/CompanionSayHiPatch.cs
@@ -1,0 +1,40 @@
+﻿using Harmony;
+using Microsoft.Xna.Framework.Graphics;
+using NpcAdventure.Events;
+using NpcAdventure.StateMachine;
+using StardewValley;
+using StardewValley.Monsters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NpcAdventure.Patches
+{
+    internal class CompanionSayHiPatch
+    {
+        private static CompanionManager manager;
+
+        internal static bool Prefix(ref NPC __instance, Character c)
+        {
+            if (manager != null && manager.PossibleCompanions.TryGetValue(__instance.Name, out CompanionStateMachine csm))
+            {
+                // Avoid say hi to monsters while companion is recruited
+                return !(csm.CurrentStateFlag == CompanionStateMachine.StateFlag.RECRUITED && c is Monster);
+            }
+
+            return true;
+        }
+
+        internal static void Setup(HarmonyInstance harmony, CompanionManager manager)
+        {
+            CompanionSayHiPatch.manager = manager;
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(NPC), nameof(NPC.sayHiTo)),
+                prefix: new HarmonyMethod(typeof(CompanionSayHiPatch), nameof(CompanionSayHiPatch.Prefix))
+            );
+        }
+    }
+}

--- a/NpcAdventure/Patches/GameLocationDrawPatch.cs
+++ b/NpcAdventure/Patches/GameLocationDrawPatch.cs
@@ -24,8 +24,13 @@ namespace NpcAdventure.Patches
             events.HandleRenderedLocation(__instance, args);
         }
 
-        internal static void Setup(ISpecialModEvents events)
+        internal static void Setup(HarmonyInstance harmony, ISpecialModEvents events)
         {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(GameLocation), "draw"),
+                postfix: new HarmonyMethod(typeof(GameLocationDrawPatch), nameof(GameLocationDrawPatch.Postfix))
+            );
+
             GameLocationDrawPatch.events = events as SpecialModEvents;
         }
     }

--- a/NpcAdventure/Patches/SpouseReturnHomePatch.cs
+++ b/NpcAdventure/Patches/SpouseReturnHomePatch.cs
@@ -1,0 +1,36 @@
+﻿using Harmony;
+using Microsoft.Xna.Framework.Graphics;
+using NpcAdventure.Events;
+using StardewValley;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NpcAdventure.Patches
+{
+    internal class SpouseReturnHomePatch
+    {
+        internal static List<string> recruitedSpouses;
+
+        internal static bool Prefix(ref NPC __instance)
+        {
+            // Ignore home return when spouse is recruited
+            if (recruitedSpouses.IndexOf(__instance.Name) >= 0)
+                return false;
+
+            return true;
+        }
+
+        internal static void Setup(HarmonyInstance harmony)
+        {
+            recruitedSpouses = new List<string>();
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(NPC), nameof(NPC.returnHomeFromFarmPosition)),
+                prefix: new HarmonyMethod(typeof(SpouseReturnHomePatch), nameof(SpouseReturnHomePatch.Prefix))
+            );
+        }
+    }
+}

--- a/NpcAdventure/StateMachine/State/RecruitedState.cs
+++ b/NpcAdventure/StateMachine/State/RecruitedState.cs
@@ -50,6 +50,12 @@ namespace NpcAdventure.StateMachine.State
             this.StateMachine.Companion.eventActor = true;
             this.StateMachine.Companion.farmerPassesThrough = true;
 
+            if (this.StateMachine.Companion.isMarried() && Patches.SpouseReturnHomePatch.recruitedSpouses.IndexOf(this.StateMachine.Companion.Name) < 0)
+            {
+                // Avoid returning recruited wife/husband to FarmHouse when is on Farm and it's after 1pm
+                Patches.SpouseReturnHomePatch.recruitedSpouses.Add(this.StateMachine.Companion.Name);
+            }
+
             this.Events.GameLoop.UpdateTicked += this.GameLoop_UpdateTicked;
             this.Events.GameLoop.TimeChanged += this.GameLoop_TimeChanged;
             this.Events.Player.Warped += this.Player_Warped;
@@ -152,6 +158,12 @@ namespace NpcAdventure.StateMachine.State
         {
             this.BuffManager.ReleaseBuffs();
             this.ai.Dispose();
+
+            if (Patches.SpouseReturnHomePatch.recruitedSpouses.IndexOf(this.StateMachine.Companion.Name) >= 0)
+            {
+                // Allow dissmised wife/husband to return to FarmHouse when is on Farm
+                Patches.SpouseReturnHomePatch.recruitedSpouses.Remove(this.StateMachine.Companion.Name);
+            }
 
             this.StateMachine.Companion.eventActor = false;
             this.StateMachine.Companion.farmerPassesThrough = false;


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Content updates (new dialogues added or some string edited and etc)
- [ ] **Merge ASAP**
- [ ] Merge before *enumerated issues or other PRs numbers*
- [ ] Merge after *enumerated issues or other PRs numbers*

## Description

This patch fixes saying hi to monsters anymore when companion is recruited and never warp to FarmHouse when recruited NPC is on Farm and is married to player.

## How to test
- While fighting NPCs never say hi to monsters (testable with Emily or Elliott)
- When NPC is married to player and recruited and is on farm after 1 pm, then companion is never warped out.

## Checklist

**Please check if the PR fulfills these requirements**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Changes was tested and passed

## Other information
---
<!-- Related issues, see https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords#about-issue-references
  For example:
    - Closes #1, fixes #2
    - Requires #5
    - Is required for #6
    - ... and some others
-->
Closes #20 