### PR TITLE
HUD remake

### DIFF
--- a/NpcAdventure/CompanionManager.cs
+++ b/NpcAdventure/CompanionManager.cs
@@ -13,6 +13,7 @@ using static NpcAdventure.StateMachine.CompanionStateMachine;
 using NpcAdventure.Model;
 using Microsoft.Xna.Framework.Graphics;
 using NpcAdventure.Events;
+using NpcAdventure.HUD;
 
 namespace NpcAdventure
 {
@@ -22,6 +23,7 @@ namespace NpcAdventure
         private readonly HintDriver hintDriver;
         private readonly IMonitor monitor;
         public Dictionary<string, CompanionStateMachine> PossibleCompanions { get; }
+        public CompanionDisplay Hud { get; }
         public Config Config { get; }
 
         public Farmer Farmer
@@ -34,10 +36,11 @@ namespace NpcAdventure
             }
         }
 
-        public CompanionManager(DialogueDriver dialogueDriver, HintDriver hintDriver, Config config, IMonitor monitor)
+        public CompanionManager(DialogueDriver dialogueDriver, HintDriver hintDriver, CompanionDisplay hud, Config config, IMonitor monitor)
         {
             this.dialogueDriver = dialogueDriver ?? throw new ArgumentNullException(nameof(dialogueDriver));
             this.hintDriver = hintDriver ?? throw new ArgumentNullException(nameof(hintDriver));
+            this.Hud = hud;
             this.monitor = monitor ?? throw new ArgumentNullException(nameof(monitor));
             this.PossibleCompanions = new Dictionary<string, CompanionStateMachine>();
             this.Config = config;

--- a/NpcAdventure/HUD/CompanionDisplay.cs
+++ b/NpcAdventure/HUD/CompanionDisplay.cs
@@ -66,20 +66,21 @@ namespace NpcAdventure.HUD
         public void DrawSkills(SpriteBatch spriteBatch)
         {
             Rectangle titleSafeArea = Game1.graphics.GraphicsDevice.Viewport.GetTitleSafeArea();
+            Vector2 position = new Vector2(Game1.viewport.Width - 70 - IClickableMenu.borderWidth, 370);
 
             for (int i = 0; i < this.Skills.Count; i++)
             {
                 var skill = this.Skills[i];
-                float xOffset = 96;
-                float yOffset = 52;
-                float iconOffset = 20;
-                Vector2 iconPosition = new Vector2(titleSafeArea.Left + xOffset + iconOffset + (i * 76), titleSafeArea.Bottom - yOffset);
-                Vector2 framePosition = new Vector2(titleSafeArea.Left + xOffset + (i * 76), titleSafeArea.Bottom - (yOffset + iconOffset) - 4);
+                float xOffset = 50;
+                float iconOffset = 16;
+                float iconGrid = 68;
+                Vector2 iconPosition = new Vector2(position.X - xOffset + iconOffset - (i * iconGrid), position.Y);
+                Vector2 framePosition = new Vector2(position.X - xOffset - (i * iconGrid), position.Y - iconOffset - 3);
 
                 if (Game1.isOutdoorMapSmallerThanViewport())
                 {
-                    iconPosition.X = Math.Max(titleSafeArea.Left + xOffset + iconOffset + (i * 76), -Game1.viewport.X + xOffset + iconOffset + (i * 76));
-                    framePosition.X = Math.Max(titleSafeArea.Left + xOffset + (i * 76), -Game1.viewport.X + xOffset + (i * 76));
+                    iconPosition.X = Math.Min(position.X, -Game1.viewport.X + Game1.currentLocation.map.Layers[0].LayerWidth * 64 - 70 - IClickableMenu.borderWidth) - xOffset + iconOffset - (i * iconGrid);
+                    framePosition.X = Math.Min(position.X, -Game1.viewport.X + Game1.currentLocation.map.Layers[0].LayerWidth * 64 - 70 - IClickableMenu.borderWidth) - xOffset - (i * iconGrid);
                 }
 
                 skill.UpdatePosition(framePosition, iconPosition);
@@ -89,11 +90,11 @@ namespace NpcAdventure.HUD
 
         public void DrawAvatar(SpriteBatch spriteBatch)
         {
-            Vector2 position = new Vector2(0, Game1.viewport.Height - 64 - IClickableMenu.borderWidth + 4);
+            Vector2 position = new Vector2(Game1.viewport.Width - 70 - IClickableMenu.borderWidth, 318);
             if (Game1.isOutdoorMapSmallerThanViewport())
-                position.X = Math.Max(position.X, (float)(-Game1.viewport.X));
+                position.X = Math.Min(position.X, -Game1.viewport.X + Game1.currentLocation.map.Layers[0].LayerWidth * 64 - 70 - IClickableMenu.borderWidth);
             Utility.makeSafe(ref position, 64, 64);
-            this.avatar.bounds = new Rectangle((int)position.X + 16, (int)position.Y, 64, 64);
+            this.avatar.bounds = new Rectangle((int)position.X + 16, (int)position.Y, 64, 96);
             this.avatar.draw(spriteBatch, Color.White, 1);
         }
 

--- a/NpcAdventure/HUD/CompanionDisplay.cs
+++ b/NpcAdventure/HUD/CompanionDisplay.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using NpcAdventure.Loader;
 using NpcAdventure.Model;
 using StardewModdingAPI.Events;
 using StardewValley;
@@ -13,11 +14,15 @@ namespace NpcAdventure.HUD
     {
         public List<CompanionSkill> Skills { get; }
         public Config Config { get; }
+        private ClickableTextureComponent avatar;
+        private string hoverText;
+        private readonly IContentLoader contentLoader;
 
-        public CompanionDisplay(Config config)
+        public CompanionDisplay(Config config, IContentLoader contentLoader)
         {
             this.Skills = new List<CompanionSkill>();
             this.Config = config;
+            this.contentLoader = contentLoader;
         }
 
         public void AddSkill(string type, string description)
@@ -25,47 +30,99 @@ namespace NpcAdventure.HUD
             this.Skills.Add(new CompanionSkill(type, description));
         }
 
+        public void AssignCompanion(NPC companion)
+        {
+            string hoverText = this.contentLoader.LoadString("Strings/Strings:recruitedCompanionHint", companion.displayName);
+            this.avatar = new ClickableTextureComponent("", Rectangle.Empty, null, hoverText, companion.Sprite.Texture, companion.getMugShotSourceRect(), 4f, false);
+        }
+
+        public void Reset()
+        {
+            this.Skills.Clear();
+            this.avatar = null;
+        }
+
         public void Draw(SpriteBatch spriteBatch)
         {
-            if (!this.Config.ShowHUD || Game1.eventUp || this.Skills.Count < 1)
+            if (!this.Config.ShowHUD || Game1.eventUp)
                 return;
 
-            CompanionSkill toolTipedSkill = null;
+            if (this.Skills.Count > 0)
+            {
+                this.DrawSkills(spriteBatch);
+            }
+
+            if (this.avatar != null)
+            {
+                this.DrawAvatar(spriteBatch);
+            }
+
+            if (!string.IsNullOrEmpty(this.hoverText))
+            {
+                IClickableMenu.drawHoverText(spriteBatch, this.hoverText, Game1.smallFont);
+            }
+        }
+
+        public void DrawSkills(SpriteBatch spriteBatch)
+        {
             Rectangle titleSafeArea = Game1.graphics.GraphicsDevice.Viewport.GetTitleSafeArea();
 
             for (int i = 0; i < this.Skills.Count; i++)
             {
                 var skill = this.Skills[i];
-                Vector2 iconPosition = new Vector2(titleSafeArea.Left + 38 + (i * 76), titleSafeArea.Bottom - 52);
-                Vector2 framePosition = new Vector2(titleSafeArea.Left + 18 + (i * 76), titleSafeArea.Bottom - 76);
+                float xOffset = 96;
+                float yOffset = 52;
+                float iconOffset = 20;
+                Vector2 iconPosition = new Vector2(titleSafeArea.Left + xOffset + iconOffset + (i * 76), titleSafeArea.Bottom - yOffset);
+                Vector2 framePosition = new Vector2(titleSafeArea.Left + xOffset + (i * 76), titleSafeArea.Bottom - (yOffset + iconOffset) - 4);
 
                 if (Game1.isOutdoorMapSmallerThanViewport())
                 {
-                    iconPosition.X = Math.Max(titleSafeArea.Left + 38 + (i * 76), -Game1.viewport.X + 38 + (i * 76));
-                    framePosition.X = Math.Max(titleSafeArea.Left + 18 + (i * 76), -Game1.viewport.X + 18 + (i * 76));
+                    iconPosition.X = Math.Max(titleSafeArea.Left + xOffset + iconOffset + (i * 76), -Game1.viewport.X + xOffset + iconOffset + (i * 76));
+                    framePosition.X = Math.Max(titleSafeArea.Left + xOffset + (i * 76), -Game1.viewport.X + xOffset + (i * 76));
                 }
-
-                if (skill.ShowTooltip)
-                    toolTipedSkill = skill;
 
                 skill.UpdatePosition(framePosition, iconPosition);
                 skill.Draw(spriteBatch);
             }
+        }
 
-            if (toolTipedSkill != null)
+        public void DrawAvatar(SpriteBatch spriteBatch)
+        {
+            Vector2 position = new Vector2(0, Game1.viewport.Height - 64 - IClickableMenu.borderWidth + 4);
+            if (Game1.isOutdoorMapSmallerThanViewport())
+                position.X = Math.Max(position.X, (float)(-Game1.viewport.X));
+            Utility.makeSafe(ref position, 64, 64);
+            this.avatar.bounds = new Rectangle((int)position.X + 16, (int)position.Y, 64, 64);
+            this.avatar.draw(spriteBatch, Color.White, 1);
+        }
+
+        public void PerformHoverAction(int x, int y)
+        {
+            this.hoverText = "";
+
+            if (this.avatar != null)
             {
-                IClickableMenu.drawHoverText(spriteBatch, toolTipedSkill.HoverText, Game1.smallFont);
+                this.avatar.tryHover(x, y, .15f);
+                if (this.avatar.containsPoint(x, y))
+                    this.hoverText = this.avatar.hoverText;
+            }
+
+            foreach (var skill in this.Skills)
+            {
+                skill.PerformHoverAction(x, y);
+                if (skill.ShowTooltip)
+                    this.hoverText = skill.HoverText;
+
             }
         }
 
         public void Update(UpdateTickedEventArgs e)
         {
-            for (int i = 0; i < this.Skills.Count; i++)
-            {
-                var skill = this.Skills[i];
+            foreach (var skill in this.Skills)
                 skill.Update(e);
-                skill.PerformHoverAction(Game1.getMouseX(), Game1.getMouseY());
-            }
+
+            this.PerformHoverAction(Game1.getMouseX(), Game1.getMouseY());
         }
     }
 }

--- a/NpcAdventure/HUD/CompanionDisplay.cs
+++ b/NpcAdventure/HUD/CompanionDisplay.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using NpcAdventure.Model;
+using StardewModdingAPI.Events;
+using StardewValley;
+using StardewValley.Menus;
+using System;
+using System.Collections.Generic;
+
+namespace NpcAdventure.HUD
+{
+    class CompanionDisplay : Internal.IDrawable, Internal.IUpdateable
+    {
+        public List<CompanionSkill> Skills { get; }
+        public Config Config { get; }
+
+        public CompanionDisplay(Config config)
+        {
+            this.Skills = new List<CompanionSkill>();
+            this.Config = config;
+        }
+
+        public void AddSkill(string type, string description)
+        {
+            this.Skills.Add(new CompanionSkill(type, description));
+        }
+
+        public void Draw(SpriteBatch spriteBatch)
+        {
+            if (!this.Config.ShowHUD || Game1.eventUp || this.Skills.Count < 1)
+                return;
+
+            CompanionSkill toolTipedSkill = null;
+            Rectangle titleSafeArea = Game1.graphics.GraphicsDevice.Viewport.GetTitleSafeArea();
+
+            for (int i = 0; i < this.Skills.Count; i++)
+            {
+                var skill = this.Skills[i];
+                Vector2 iconPosition = new Vector2(titleSafeArea.Left + 38 + (i * 76), titleSafeArea.Bottom - 52);
+                Vector2 framePosition = new Vector2(titleSafeArea.Left + 18 + (i * 76), titleSafeArea.Bottom - 76);
+
+                if (Game1.isOutdoorMapSmallerThanViewport())
+                {
+                    iconPosition.X = Math.Max(titleSafeArea.Left + 38 + (i * 76), -Game1.viewport.X + 38 + (i * 76));
+                    framePosition.X = Math.Max(titleSafeArea.Left + 18 + (i * 76), -Game1.viewport.X + 18 + (i * 76));
+                }
+
+                if (skill.ShowTooltip)
+                    toolTipedSkill = skill;
+
+                skill.UpdatePosition(framePosition, iconPosition);
+                skill.Draw(spriteBatch);
+            }
+
+            if (toolTipedSkill != null)
+            {
+                IClickableMenu.drawHoverText(spriteBatch, toolTipedSkill.HoverText, Game1.smallFont);
+            }
+        }
+
+        public void Update(UpdateTickedEventArgs e)
+        {
+            for (int i = 0; i < this.Skills.Count; i++)
+            {
+                var skill = this.Skills[i];
+                skill.Update(e);
+                skill.PerformHoverAction(Game1.getMouseX(), Game1.getMouseY());
+            }
+        }
+    }
+}

--- a/NpcAdventure/HUD/CompanionSkill.cs
+++ b/NpcAdventure/HUD/CompanionSkill.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI.Events;
+using StardewValley;
+
+namespace NpcAdventure.HUD
+{
+    class CompanionSkill : Internal.IDrawable, Internal.IUpdateable
+    {
+        private Vector2 framePosition;
+        private Vector2 iconPosition;
+
+        public CompanionSkill(string type, string description)
+        {
+            this.Type = type;
+            this.HoverText = description;
+        }
+
+        public string Type { get; }
+        public int Index { get; set; }
+        public bool ShowTooltip { get; private set; }
+        public string HoverText { get; set; }
+
+        public void Draw(SpriteBatch spriteBatch)
+        {
+            Rectangle icon;
+
+            switch (this.Type)
+            {
+                case "doctor":
+                    icon = new Rectangle(0, 428, 10, 10);
+                    break;
+                case "warrior":
+                    icon = new Rectangle(120, 428, 10, 10);
+                    break;
+                case "fighter":
+                    icon = new Rectangle(40, 428, 10, 10);
+                    break;
+                default:
+                    return;
+            }
+
+            spriteBatch.Draw(Game1.mouseCursors, this.framePosition, new Rectangle(384, 373, 18, 18), Color.White * 1f, 0f, Vector2.Zero, 4f, SpriteEffects.None, 1f);
+            spriteBatch.Draw(Game1.mouseCursors, this.iconPosition, icon, Color.White * 1f, 0f, Vector2.Zero, 3f, SpriteEffects.None, 1f);
+        }
+
+        public void PerformHoverAction(int x, int y)
+        {
+            Rectangle frameBounding = new Rectangle((int)this.framePosition.X, (int)this.framePosition.Y, 18 * 4, 18 * 4);
+
+            if (frameBounding.Contains(x, y))
+            {
+                this.ShowTooltip = true;
+                return;
+            }
+
+            this.ShowTooltip = false;
+        }
+
+        internal void UpdatePosition(Vector2 framePosition, Vector2 iconPosition)
+        {
+            this.framePosition = framePosition;
+            this.iconPosition = iconPosition;
+        }
+
+        public void Update(UpdateTickedEventArgs e)
+        {
+
+        }
+    }
+}

--- a/NpcAdventure/HUD/CompanionSkill.cs
+++ b/NpcAdventure/HUD/CompanionSkill.cs
@@ -40,8 +40,8 @@ namespace NpcAdventure.HUD
                     return;
             }
 
-            spriteBatch.Draw(Game1.mouseCursors, this.framePosition, new Rectangle(384, 373, 18, 18), Color.White * 1f, 0f, Vector2.Zero, 4f, SpriteEffects.None, 1f);
-            spriteBatch.Draw(Game1.mouseCursors, this.iconPosition, icon, Color.White * 1f, 0f, Vector2.Zero, 3f, SpriteEffects.None, 1f);
+            spriteBatch.Draw(Game1.mouseCursors, this.framePosition, new Rectangle(384, 373, 18, 18), Color.White * 1f, 0f, Vector2.Zero, 3.4f, SpriteEffects.None, 1f);
+            spriteBatch.Draw(Game1.mouseCursors, this.iconPosition, icon, Color.White * 1f, 0f, Vector2.Zero, 2.8f, SpriteEffects.None, 1f);
         }
 
         public void PerformHoverAction(int x, int y)

--- a/NpcAdventure/NpcAdventure.csproj
+++ b/NpcAdventure/NpcAdventure.csproj
@@ -83,6 +83,8 @@
     <Compile Include="Driver\StuffDriver.cs" />
     <Compile Include="Events\ISpecialModEvents.cs" />
     <Compile Include="Events\SpecialModEvents.cs" />
+    <Compile Include="HUD\CompanionDisplay.cs" />
+    <Compile Include="HUD\CompanionSkill.cs" />
     <Compile Include="Internal\IDrawable.cs" />
     <Compile Include="Loader\ContentPacks\AssetPatch.cs" />
     <Compile Include="Loader\AssetsManager.cs" />

--- a/NpcAdventure/NpcAdventureMod.cs
+++ b/NpcAdventure/NpcAdventureMod.cs
@@ -69,7 +69,7 @@ namespace NpcAdventure
             this.HintDriver = new HintDriver(this.Helper.Events);
             this.StuffDriver = new StuffDriver(this.Helper.Data, this.Monitor);
             this.contentLoader = new ContentLoader(this.Helper.Content, this.Helper.ContentPacks, this.ModManifest.UniqueID, "assets", this.Helper.DirectoryPath, this.Monitor);
-            this.companionHud = new CompanionDisplay(this.config);
+            this.companionHud = new CompanionDisplay(this.config, this.contentLoader);
             this.companionManager = new CompanionManager(this.DialogueDriver, this.HintDriver, this.companionHud, this.config, this.Monitor);
             this.StuffDriver.RegisterEvents(this.Helper.Events);
             

--- a/NpcAdventure/NpcAdventureMod.cs
+++ b/NpcAdventure/NpcAdventureMod.cs
@@ -10,6 +10,7 @@ using Harmony;
 using System.Reflection;
 using NpcAdventure.Events;
 using NpcAdventure.Model;
+using NpcAdventure.HUD;
 
 namespace NpcAdventure
 {
@@ -17,6 +18,7 @@ namespace NpcAdventure
     public class NpcAdventureMod : Mod
     {
         private CompanionManager companionManager;
+        private CompanionDisplay companionHud;
 
         public static IMonitor GameMonitor { get; private set; }
 
@@ -44,6 +46,20 @@ namespace NpcAdventure
             events.GameLoop.DayEnding += this.GameLoop_DayEnding;
             events.GameLoop.DayStarted += this.GameLoop_DayStarted;
             events.GameLoop.GameLaunched += this.GameLoop_GameLaunched;
+            events.GameLoop.UpdateTicked += this.GameLoop_UpdateTicked;
+            events.Display.RenderedHud += this.Display_RenderedHud;
+        }
+
+        private void Display_RenderedHud(object sender, RenderedHudEventArgs e)
+        {
+            if (Context.IsWorldReady && this.companionHud != null)
+                this.companionHud.Draw(e.SpriteBatch);
+        }
+
+        private void GameLoop_UpdateTicked(object sender, UpdateTickedEventArgs e)
+        {
+            if (Context.IsWorldReady && this.companionHud != null)
+                this.companionHud.Update(e);
         }
 
         private void GameLoop_GameLaunched(object sender, GameLaunchedEventArgs e)
@@ -53,7 +69,8 @@ namespace NpcAdventure
             this.HintDriver = new HintDriver(this.Helper.Events);
             this.StuffDriver = new StuffDriver(this.Helper.Data, this.Monitor);
             this.contentLoader = new ContentLoader(this.Helper.Content, this.Helper.ContentPacks, this.ModManifest.UniqueID, "assets", this.Helper.DirectoryPath, this.Monitor);
-            this.companionManager = new CompanionManager(this.DialogueDriver, this.HintDriver, this.config, this.Monitor);
+            this.companionHud = new CompanionDisplay(this.config);
+            this.companionManager = new CompanionManager(this.DialogueDriver, this.HintDriver, this.companionHud, this.config, this.Monitor);
             this.StuffDriver.RegisterEvents(this.Helper.Events);
             
             //Harmony

--- a/NpcAdventure/StateMachine/State/RecruitedState.cs
+++ b/NpcAdventure/StateMachine/State/RecruitedState.cs
@@ -53,7 +53,6 @@ namespace NpcAdventure.StateMachine.State
             this.Events.GameLoop.UpdateTicked += this.GameLoop_UpdateTicked;
             this.Events.GameLoop.TimeChanged += this.GameLoop_TimeChanged;
             this.Events.Player.Warped += this.Player_Warped;
-            this.Events.Display.RenderingHud += this.Display_RenderingHud;
             this.SpecialEvents.RenderedLocation += this.SpecialEvents_RenderedLocation;
 
             if (this.BuffManager.HasAssignableBuffs())
@@ -65,72 +64,20 @@ namespace NpcAdventure.StateMachine.State
                 this.StateMachine.Companion.setNewDialogue(dialogueText);
             this.CanCreateDialogue = true;
 
+            foreach (string skill in this.StateMachine.Metadata.PersonalSkills)
+            {
+                string text = this.StateMachine.ContentLoader.LoadString($"Strings/Strings:skill.{skill}", this.StateMachine.Companion.displayName)
+                        + Environment.NewLine
+                        + this.StateMachine.ContentLoader.LoadString($"Strings/Strings:skillDescription.{skill}");
+                this.StateMachine.CompanionManager.Hud.AddSkill(skill, text);
+            }
+
             this.ai.Setup();
         }
 
         private void SpecialEvents_RenderedLocation(object sender, ILocationRenderedEventArgs e)
         {
             this.ai.Draw(e.SpriteBatch);
-        }
-
-        private void Display_RenderingHud(object sender, RenderingHudEventArgs e)
-        {
-            if (!this.StateMachine.CompanionManager.Config.ShowHUD || Game1.eventUp)
-                return;
-
-            var skills = this.StateMachine.Metadata.PersonalSkills;
-            string toolTipedSkill = "";
-            bool drawTooltip = false;
-            int i = 0;
-            foreach (string skill in skills)
-            {
-                Rectangle titleSafeArea = Game1.graphics.GraphicsDevice.Viewport.GetTitleSafeArea();
-                Rectangle icon;
-                Vector2 vector2 = new Vector2(titleSafeArea.Left + 38 + (i * 76), titleSafeArea.Bottom - 52);
-                Vector2 vector3 = new Vector2(titleSafeArea.Left + 18 + (i * 76), titleSafeArea.Bottom - 76);
-
-                if (Game1.isOutdoorMapSmallerThanViewport())
-                {
-                    vector2.X = Math.Max(titleSafeArea.Left + 38 + (i * 76), -Game1.viewport.X + 38 + (i * 76));
-                    vector3.X = Math.Max(titleSafeArea.Left + 18 + (i * 76), -Game1.viewport.X + 18 + (i * 76));
-                }
-
-                switch (skill)
-                {
-                    case "doctor":
-                        icon = new Rectangle(0, 428, 10, 10);
-                        break;
-                    case "warrior":
-                        icon = new Rectangle(120, 428, 10, 10);
-                        break;
-                    case "fighter":
-                        icon = new Rectangle(40, 428, 10, 10);
-                        break;
-                    default:
-                        continue;
-                }
-
-                e.SpriteBatch.Draw(Game1.mouseCursors, vector3, new Rectangle(384, 373, 18, 18), Color.White * 1f, 0f, Vector2.Zero, 4f, SpriteEffects.None, 1f);
-                e.SpriteBatch.Draw(Game1.mouseCursors, vector2, icon, Color.White * 1f, 0f, Vector2.Zero, 3f, SpriteEffects.None, 1f);
-
-                Rectangle bounding = new Rectangle((int)vector3.X, (int)vector3.Y, 18 * 4, 18 * 4);
-
-                if (bounding.Contains(Game1.getMouseX(), Game1.getMouseY()))
-                {
-                    toolTipedSkill = skill;
-                    drawTooltip = true;
-                }
-
-                i++;
-            }
-
-            if (drawTooltip)
-            {
-                string text = this.StateMachine.ContentLoader.LoadString($"Strings/Strings:skill.{toolTipedSkill}", this.StateMachine.Companion.displayName)
-                        + Environment.NewLine
-                        + this.StateMachine.ContentLoader.LoadString($"Strings/Strings:skillDescription.{toolTipedSkill}");
-                IClickableMenu.drawHoverText(e.SpriteBatch, text, Game1.smallFont);
-            }
         }
 
         /// <summary>
@@ -161,10 +108,10 @@ namespace NpcAdventure.StateMachine.State
             this.Events.GameLoop.UpdateTicked -= this.GameLoop_UpdateTicked;
             this.Events.GameLoop.TimeChanged -= this.GameLoop_TimeChanged;
             this.Events.Player.Warped -= this.Player_Warped;
-            this.Events.Display.RenderingHud -= this.Display_RenderingHud;
 
             this.ai = null;
             this.dismissalDialogue = null;
+            this.StateMachine.CompanionManager.Hud.Skills.Clear();
         }
 
         private void GameLoop_TimeChanged(object sender, TimeChangedEventArgs e)

--- a/NpcAdventure/StateMachine/State/RecruitedState.cs
+++ b/NpcAdventure/StateMachine/State/RecruitedState.cs
@@ -72,6 +72,7 @@ namespace NpcAdventure.StateMachine.State
                 this.StateMachine.CompanionManager.Hud.AddSkill(skill, text);
             }
 
+            this.StateMachine.CompanionManager.Hud.AssignCompanion(this.StateMachine.Companion);
             this.ai.Setup();
         }
 
@@ -111,7 +112,7 @@ namespace NpcAdventure.StateMachine.State
 
             this.ai = null;
             this.dismissalDialogue = null;
-            this.StateMachine.CompanionManager.Hud.Skills.Clear();
+            this.StateMachine.CompanionManager.Hud.Reset();
         }
 
         private void GameLoop_TimeChanged(object sender, TimeChangedEventArgs e)

--- a/NpcAdventure/assets/Strings/Strings.json
+++ b/NpcAdventure/assets/Strings/Strings.json
@@ -13,5 +13,6 @@
   "skill.doctor": "Doctor ({0}'s skill)",
   "skillDescription.doctor": "Can heal you when your health is unde 30%.",
   "skill.fighter": "Fighter ({0}'s skill)",
-  "skillDescription.fighter": "Can fight with sword."
+  "skillDescription.fighter": "Can fight with sword.",
+  "recruitedCompanionHint": "Recruited companion: {0}"
 }

--- a/NpcAdventure/assets/Strings/Strings.json
+++ b/NpcAdventure/assets/Strings/Strings.json
@@ -11,7 +11,7 @@
   "skill.warrior": "Warrior ({0}'s skill)",
   "skillDescription.warrior": "Can fight with sword and use critical defense in danger.",
   "skill.doctor": "Doctor ({0}'s skill)",
-  "skillDescription.doctor": "Can heal you when your health is unde 30%.",
+  "skillDescription.doctor": "Can heal you when your health is under 30%.",
   "skill.fighter": "Fighter ({0}'s skill)",
   "skillDescription.fighter": "Can fight with sword.",
   "recruitedCompanionHint": "Recruited companion: {0}"

--- a/NpcAdventure/assets/Strings/Strings.pt-BR.json
+++ b/NpcAdventure/assets/Strings/Strings.pt-BR.json
@@ -13,5 +13,6 @@
   "skill.doctor": "Doutor ({0} de habilidade)",
   "skillDescription.doctor": "Pode te curar quando sua vida está abaixo de  30%.",
   "skill.fighter": "Lutador ({0} de habilidade)",
-  "skillDescription.fighter": "Luta com espadas."
+  "skillDescription.fighter": "Luta com espadas.",
+  "recruitedCompanionHint": "Companhias recrutadas: {0}"
 }


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Content updates (new dialogues added or some string edited and etc)
- [ ] **Merge ASAP**
- [ ] Merge before *enumerated issues or other PRs numbers*
- [ ] Merge after *enumerated issues or other PRs numbers*

## Description
Refactored HUD, moved under game clock and added companion avatar.

## How to test
HUD works with the same functionality like before refactoring, views under game clock and recruited NPC avatar is show.

![Poznámka 2019-12-08 155028](https://user-images.githubusercontent.com/4710267/70391828-8ea50b00-19d9-11ea-9fee-e8071cac5671.png)

## Checklist

**Please check if the PR fulfills these requirements**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Changes was tested and passed

## Other information
---
<!-- Related issues, see https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords#about-issue-references
  For example:
    - Closes #1, fixes #2
    - Requires #5
    - Is required for #6
    - ... and some others
-->
