### PR TITLE
Added Maru, Emily and Shane location dialogue lines

### DIFF
--- a/NpcAdventure/Driver/DialogueDriver.cs
+++ b/NpcAdventure/Driver/DialogueDriver.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.Xna.Framework;
+using NpcAdventure.Internal;
 using NpcAdventure.Utils;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
@@ -71,7 +72,6 @@ namespace NpcAdventure.Driver
 
             foreach (NPC npc in farmer.currentLocation.characters) {
                 Rectangle npcBox = npc.GetBoundingBox();
-                Rectangle spriteBox = npc.Sprite.SourceRect;
                 bool isNpcAtCursorTile = Helper.IsNPCAtTile(farmer.currentLocation, e.Cursor.Tile, npc)
                                          || Helper.IsNPCAtTile(farmer.currentLocation, e.Cursor.Tile + new Vector2(0f, 1f), npc)
                                          || Helper.IsNPCAtTile(farmer.currentLocation, e.Cursor.GrabTile, npc);
@@ -108,7 +108,17 @@ namespace NpcAdventure.Driver
             if (this.CurrentDialogue != dialogue)
             {
                 this.OnChangeDialogue(this.CurrentDialogue, dialogue, this.CurrentSpeaker?.CurrentDialogue?.Count <= 1);
+                this.TryRemember(dialogue);
                 this.CurrentDialogue = dialogue;
+            }
+        }
+
+        private void TryRemember(Dialogue dialogue)
+        {
+            if (dialogue is CompanionDialogue companionDialogue && companionDialogue.Remember && !string.IsNullOrEmpty(companionDialogue.Tag))
+            {
+                if (!Game1.player.hasOrWillReceiveMail(companionDialogue.Tag))
+                    Game1.player.mailReceived.Add(companionDialogue.Tag);
             }
         }
 

--- a/NpcAdventure/Internal/CompanionDialogue.cs
+++ b/NpcAdventure/Internal/CompanionDialogue.cs
@@ -1,0 +1,18 @@
+﻿using StardewValley;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NpcAdventure.Internal
+{
+    internal class CompanionDialogue : Dialogue
+    {
+        public string Tag { get; set; }
+        public bool Remember { get; set; }
+        public CompanionDialogue(string masterDialogue, NPC speaker) : base(masterDialogue, speaker)
+        {
+        }
+    }
+}

--- a/NpcAdventure/NpcAdventure.csproj
+++ b/NpcAdventure/NpcAdventure.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Events\SpecialModEvents.cs" />
     <Compile Include="HUD\CompanionDisplay.cs" />
     <Compile Include="HUD\CompanionSkill.cs" />
+    <Compile Include="Internal\CompanionDialogue.cs" />
     <Compile Include="Internal\IDrawable.cs" />
     <Compile Include="Loader\ContentPacks\AssetPatch.cs" />
     <Compile Include="Loader\AssetsManager.cs" />

--- a/NpcAdventure/StateMachine/State/RecruitedState.cs
+++ b/NpcAdventure/StateMachine/State/RecruitedState.cs
@@ -15,6 +15,7 @@ using StardewModdingAPI;
 using NpcAdventure.AI;
 using Microsoft.Xna.Framework.Graphics;
 using NpcAdventure.Events;
+using NpcAdventure.Internal;
 
 namespace NpcAdventure.StateMachine.State
 {
@@ -192,11 +193,25 @@ namespace NpcAdventure.StateMachine.State
             this.TryPushLocationDialogue(e.NewLocation);
         }
 
+        private Dialogue GenerateLocationDialogue(GameLocation location, NPC companion)
+        {
+            if (DialogueHelper.GenerateStaticDialogue(companion, location, "companionOnce") is CompanionDialogue dialogueOnce
+                && !this.StateMachine.CompanionManager.Farmer.hasOrWillReceiveMail(dialogueOnce.Tag))
+            {
+                // Remember only once spoken dialogue
+                dialogueOnce.Remember = true;
+                return dialogueOnce;
+            }
+
+            // Generate standard companion various dialogue if no once dialogue defined or once dialogue spoken
+            return DialogueHelper.GenerateDialogue(companion, location, "companion");
+        }
+
         private bool TryPushLocationDialogue(GameLocation location)
         {
             NPC companion = this.StateMachine.Companion;
-            Dialogue newDialogue = DialogueHelper.GenerateDialogue(companion, location, "companion");
             Stack<Dialogue> temp = new Stack<Dialogue>(this.StateMachine.Companion.CurrentDialogue.Count);
+            Dialogue newDialogue = this.GenerateLocationDialogue(location, companion);
 
             if ((newDialogue == null && this.currentLocationDialogue == null) || (newDialogue != null && newDialogue.Equals(this.currentLocationDialogue)))
                 return false;

--- a/NpcAdventure/Utils/DialogueHelper.cs
+++ b/NpcAdventure/Utils/DialogueHelper.cs
@@ -1,4 +1,5 @@
-﻿using StardewModdingAPI.Utilities;
+﻿using NpcAdventure.Internal;
+using StardewModdingAPI.Utilities;
 using StardewValley;
 using System;
 using System.Collections.Generic;
@@ -11,14 +12,16 @@ namespace NpcAdventure.Utils
         private static bool GetDialogueString(Dictionary<string, string> dialogues, string key, out string text)
         {
             var keys = from _key in dialogues.Keys
-                       where _key.StartsWith(key + "$")
+                       where _key.StartsWith(key + "~") || _key.StartsWith(key + "$")
                        select _key;
 
             if (keys.Count() > 0)
             {
-                int i = Game1.random.Next(keys.Count() + 1);
+                int i = Game1.random.Next(0, keys.Count() + 1);
 
-                if (i > 0 && dialogues.TryGetValue($"{key}${i}", out text))
+                Console.WriteLine($"{i} of {keys.Count()}");
+
+                if (i < keys.Count() && dialogues.TryGetValue(keys.ElementAt(i), out text))
                     return true;
             }
 
@@ -95,7 +98,7 @@ namespace NpcAdventure.Utils
         public static Dialogue GenerateDialogue(NPC n, string key, bool returnsNull = true)
         {
             if (GetVariousDialogueString(n, key, out string text) || !returnsNull)
-                return new Dialogue(text, n);
+                return new CompanionDialogue(text, n) { Tag = $"{n.Name}_{key}" };
 
             return null;
         }
@@ -103,9 +106,26 @@ namespace NpcAdventure.Utils
         public static Dialogue GenerateDialogue(NPC n, GameLocation l, string key, bool returnsNull = true)
         {
             if (GetVariousDialogueString(n, key, l, out string text) || !returnsNull)
-                return new Dialogue(text, n);
+            {
+                return new CompanionDialogue(text, n) { Tag = $"{n.Name}_{key}_{l.Name}" };
+            }
 
             return null;
+        }
+
+        public static Dialogue GenerateStaticDialogue(NPC n, string key)
+        {
+            if (GetDialogueString(n, key, out string text))
+            {
+                return new CompanionDialogue(text, n) { Tag = $"{n.Name}_{key}" };
+            }
+
+            return null;
+        }
+
+        public static Dialogue GenerateStaticDialogue(NPC n, GameLocation l, string key)
+        {
+            return GenerateStaticDialogue(n, $"{key}_{l.Name}");
         }
 
         public static void SetupCompanionDialogues(NPC n, Dictionary<string, string> dialogues)

--- a/NpcAdventure/assets/Dialogue/Emily.json
+++ b/NpcAdventure/assets/Dialogue/Emily.json
@@ -4,5 +4,11 @@
   "companionRejectedNight": "Don't you know it's dangerous to explore at night?",
   "companionDismiss": "Alright, I'll see you later!",
   "companionDismissAuto": "Sorry @ I have to go. Haley is terrible at cooking and if I'm not there she'll burn the house down!",
-  "companionRecruited": "Lead the way.$h"
+  "companionRecruited": "Lead the way.$h",
+  "companion_Beach": "Oh, I want to look for some urchins! Did you know they make beautiful dyes?",
+  "companion_Farm": "I hope all your crops are organic, @. I'm sure they'll taste better that way",
+  "companion_Forest": "This forest is always brimming with powerful energies. I wonder why...",
+  "companion_Mine": "I should use this opportunity to gather some crystals.$h",
+  "companion_Mountain": "I think Linus choose such a nice place to live, don't you agree?",
+  "companion_Town": "I'm glad that Gus let me take this day off. Let's have some fun!$h"
 }

--- a/NpcAdventure/assets/Dialogue/Maru.fr-FR.json
+++ b/NpcAdventure/assets/Dialogue/Maru.fr-FR.json
@@ -6,5 +6,11 @@
   "companionDismissAuto": "Il est l'heure que j'y aille. Merci d'avoir revigoré ma journée @!$h",
   "companionRecruited": "Je me demande si l'on va decouvrir quelquechose.$h",
   "heal": "J'vais te rafistoler.$3",
-  "nomedkits": "Faut que je passe à la clinique, je n'ai plus de médikit.$6"
+  "nomedkits": "Faut que je passe à la clinique, je n'ai plus de médikit.$6",
+  "companion_Forest_Night": "C'est un peu sinistre ici, @.$s#$b#Mais cette atmosphère me donne une nouvelle idée ! J'aurais du prendre mon carnet...#$b#Bon, je ne l'oublierais pas. J'espère.$h",
+  "companion_Beach_Night": "Wow, regarde ce ciel, ces étoiles !$h#$b#La lune se reflète sur l'ocean et tout est si clair. C'est presque magique, tu ne crois pas @?$l",
+  "companionOnce_Mine": "Oh les mines ! J'ai trop peur pour venir ici seule, je ne suis pas vraiment une guerrière.#$b#Mais avec la clinique, les premiers soins n'ont plus de secret pour moi, si tu te blesses je serais là pour toi !#$b#Allez, à l'aventure !$h",
+  "companion_Mine": "Les mines, c'est tellement excitant !$l#$b#Tu penses qu'on va découvrir quelquechose ?",
+  "companion_Mine~1": "Je suis contente d'être avec une personne combattante comme toi, @.#$b# Avec mes soins, on forme une super équipe !$h",
+  "companion_Mine~2": "Merci pour la balade aux mines aujourd'hui, @.#$b#J'ai toujours besoin de métal pour mes projets!$h"
 }

--- a/NpcAdventure/assets/Dialogue/Maru.json
+++ b/NpcAdventure/assets/Dialogue/Maru.json
@@ -7,10 +7,10 @@
   "companionRecruited": "I wonder if we'll discover anything new.$h",
   "heal": "Let's get you patched up.$3",
   "nomedkits": "I'll have to stop by Harvey's Clinic, I haven't got any more bandages.$6",
-  "companion_Forest_Night": "It’s pretty creepy here right now, @.$s#$b#But this atmosphere is giving me a new idea for an invention! I should have brought my notepad...#$b#Oh well, I probably won’t forget it. Probably.$h",
-  "companion_Beach_Night": "Wow, look at that night sky!$h#$b#The way the moon is reflecting on the ocean, everything’s so clear. It’s almost magical, don’t you think @?$l",
-  "companionOnce_Mine": "Oh the mines! I’m always too scared to come here alone, I’m not much of a fighter.#$b#But I’ve learned some simple healing methods from working at the clinic, so if you get hurt I can help!#$b#C’mon, let’s go! Discoveries await!$h",
-  "companion_Mine": "The mines, this is so exciting!$l#$b#Do you think we’ll find anything new?",
-  "companion_Mine~1": "I’m glad I’m here with a fighter like you, @.#$b#With my healing skills, we make a pretty good team!$h",
+  "companion_Forest_Night": "It's pretty creepy here right now, @.$s#$b#But this atmosphere is giving me a new idea for an invention! I should have brought my notepad...#$b#Oh well, I probably won't forget it. Probably.$h",
+  "companion_Beach_Night": "Wow, look at that night sky!$h#$b#The way the moon is reflecting on the ocean, everything's so clear. It's almost magical, don't you think @?$l",
+  "companionOnce_Mine": "Oh the mines! I'm always too scared to come here alone, I'm not much of a fighter.#$b#But I've learned some simple healing methods from working at the clinic, so if you get hurt I can help!#$b#C'mon, let's go! Discoveries await!$h",
+  "companion_Mine": "The mines, this is so exciting!$l#$b#Do you think we'll find anything new?",
+  "companion_Mine~1": "I'm glad I'm here with a fighter like you, @.#$b#With my healing skills, we make a pretty good team!$h",
   "companion_Mine~2": "Thank you for taking me to the mines today, @.#$b#I always need more metal for my projects!$h"
 }

--- a/NpcAdventure/assets/Dialogue/Maru.json
+++ b/NpcAdventure/assets/Dialogue/Maru.json
@@ -6,5 +6,11 @@
   "companionDismissAuto": "It's time for me to head home. Thanks for a refreshing day @!$h",
   "companionRecruited": "I wonder if we'll discover anything new.$h",
   "heal": "Let's get you patched up.$3",
-  "nomedkits": "I'll have to stop by Harvey's Clinic, I haven't got any more bandages.$6"
+  "nomedkits": "I'll have to stop by Harvey's Clinic, I haven't got any more bandages.$6",
+  "companion_Forest_Night": "It’s pretty creepy here right now, @.$s#$b#But this atmosphere is giving me a new idea for an invention! I should have brought my notepad...#$b#Oh well, I probably won’t forget it. Probably.$h",
+  "companion_Beach_Night": "Wow, look at that night sky!$h#$b#The way the moon is reflecting on the ocean, everything’s so clear. It’s almost magical, don’t you think @?$l",
+  "companionOnce_Mine": "Oh the mines! I’m always too scared to come here alone, I’m not much of a fighter.#$b#But I’ve learned some simple healing methods from working at the clinic, so if you get hurt I can help!#$b#C’mon, let’s go! Discoveries await!$h",
+  "companion_Mine": "The mines, this is so exciting!$l#$b#Do you think we’ll find anything new?",
+  "companion_Mine~1": "I’m glad I’m here with a fighter like you, @.#$b#With my healing skills, we make a pretty good team!$h",
+  "companion_Mine~2": "Thank you for taking me to the mines today, @.#$b#I always need more metal for my projects!$h"
 }

--- a/NpcAdventure/assets/Dialogue/Maru.pt-BR.json
+++ b/NpcAdventure/assets/Dialogue/Maru.pt-BR.json
@@ -1,10 +1,17 @@
 ﻿{
-  "companionAccepted": "Que ideia excelente!$h Eu já ia mesmo sair pra coletar umas amostras de solo.",
-  "companionRejected": "Não posso ir agora, tenho que analisar umas amostras.",
-  "companionRejectedNight": "Agora não. Tenho um projeto importante pra terminar.",
-  "companionDismiss": "Eu já coletei amostras o suficiente por enquanto. Obrigada @.",
-  "companionDismissAuto": "Já está na hora de eu voltar pra casa. Obrigada pelo dia divertido @!$h",
-  "companionRecruited": "Eu penso se vamos conseguir descobrir algo novo.$h",
-  "heal": "Vamos cuidar dos machucados.$3",
-  "nomedkits": "Os band-aids acabaram, preciso passar na Clínica do Harvey.$6"
+  "companionAccepted": "Que ideia excelente!$h Eu estava me preparando pra coletar algumas amostras de solo.",
+  "companionRejected": "Agora eu não posso. Eu tenho coisas importantes no laboratório pra fazer.",
+  "companionRejectedNight": "Agora não. Eu estou trabalhando em um projeto importante.",
+  "companionDismiss": "Eu já coletei amostras o suficiente por agora. Obrigada.",
+  "companionDismissAuto": "Já é hora de eu ir pra casa. Obrigada pelo dia excepcional @!$h",
+  "companionRecruited": "Eu penso se vamos acabar descobrindo algo novo.$h",
+  "heal": "Deixa eu te ajudar aqui.$3",
+  "nomedkits": "Eu vou ter que passar na clínica do Harvey, meus band-aids acabaram de vez.$6",
+  "companion_Forest_Night": "Esss lugar é muito assustador, @.$s#$b#Mas essa atmosfera me dá uma bela Idea pra uma invenção! Eu deveria ter trazido meu caderno de notas...#$b#Mas bem, talvez eu não vá esquecer. Talvez.$h",
+  "companion_Beach_Night": "Wow, olha pra esse céu!$h#$b#O jeito que a lua reflete no oceano, tudo é tão nítido. É quase mágico, não acha @?$l",
+  "companionOnce_Mine": "Ah as minas! Eu sempre tenho medo demais pra vir aqui, Eu não sou muito de lutar.#$b#Mas eu aprendi algumas coisas sobre primeiros socorros na clínica, então eu posso ajudar você se se machucar!#$b#Tá bom, vamos lá! Descobertas aguardam!$h",
+  "companion_Mine": "As minas, isso é tão empolgante!$l#$b#Você pensa que vamos ver algo novo?",
+  "companion_Mine~1": "Eu me sinto melhor com alguém que sabe lutar aqui, @.#$b#Comigo sabendo curar, seremos uma bela dupla!$h",
+  "companion_Mine~2": "Obrigada por me trazer aqui hoje, @.#$b#Eu sempre preciso de mais metal para os meus projetos!$h"
 }
+ 

--- a/NpcAdventure/assets/Dialogue/Shane.json
+++ b/NpcAdventure/assets/Dialogue/Shane.json
@@ -4,5 +4,14 @@
   "companionRejectedNight": "I'm going to the saloon tonight.",
   "companionDismiss": "I guess I'll head to the saloon. What else is there to do?",
   "companionDismissAuto": "I'm going to go to the saloon now. Bye.",
-  "companionRecruited": "I don't have all day."
+  "companionRecruited": "I don't have all day.",
+  "companion_Beach": "I'm really not the biggest fan of sand and surf, but there's something peaceful about this beach.",
+  "companion_Beach~1": "Wouldn't it be cool if they set up a tiki bar here?#$b#Like the saloon, but with beach themed food and drinks.#$b#Yeah, and non-alcoholic options. For the kids and stuff, and maybe us big kids too.$h",
+  "companion_Beach~2": "I can't even remember the last time I went fishing.#$b#I wonder if Willy could give me some tips?",
+  "companion_Forest": "This fresh air is doing wonders for my mood.$h#$b#I appreciate the invite today, @.",
+  "companion_Mine": "Ugh. Seriously, @, the mines?$a#$b#Couldn't we just hang out at the saloon?$s",
+  "companion_Mine~1": "It's so dark and dingy in here.$s#$b#Like I'm not depressed enough already.$s",
+  "companion_Mine~2": "Oh. We're at the mines.#$b#It's a good thing I know how to fight.$6",
+  "companion_Mine~3": "I must have slept okay last night, because this isn't totally bumming me out.$6#$b#Let's mine some ore! Or whatever.$h",
+  "companion_Saloon": "Ah, my ol' home away from home.$h#$b#Good choice, @.$h"
 }


### PR DESCRIPTION
- Added support for only once companion dialogues per game
- Added ~ for mark randomized dialogues ($ still works, but deprecated)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Content updates (new dialogues added or some string edited and etc)
- [ ] **Merge ASAP**
- [ ] Merge before *enumerated issues or other PRs numbers*
- [ ] Merge after *enumerated issues or other PRs numbers*

## Description
- Adds a Maru location dialogue lines for some locations.
- Adds a support for companion dialogue which can be spoken only **once per game** - key `companionOnce_<location>`. This dialogue is static, no variations.
- Replaces randomize key char `$` with `~`. The old still works, but it's deprecated. **Don't use it in new dialogues!**

## How to test
Dialogues for Maru perfectly works!
`companionOnce_Mine` for Maru shown only once per game save.

## Checklist

**Please check if the PR fulfills these requirements**
- [x] My change requires a change to the documentation.
  - Add new key for game once dialogue to docs
  - Edit randomize dialogue key in docs ($ -> ~)
- [x] I have updated the documentation accordingly.
- [ ] Changes was tested and passed

## Other information
---
<!-- Related issues, see https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords#about-issue-references
  For example:
    - Closes #1, fixes #2
    - Requires #5
    - Is required for #6
    - ... and some others
-->
Refs #13 