### PR TITLE
Added compatibility with Custom Kissing mod by Digus

### DIFF
--- a/NpcAdventure/Compatibility/CustomKissing.cs
+++ b/NpcAdventure/Compatibility/CustomKissing.cs
@@ -1,0 +1,37 @@
+﻿using StardewModdingAPI;
+using StardewValley;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NpcAdventure.Compatibility
+{
+    /// <summary>
+    /// Proxy to Custom Kissing Mod by Digus for keep compatibility with this mod.
+    /// </summary>
+    internal class CustomKissing
+    {
+        private readonly ICustomKissingModApi api;
+
+        public CustomKissing(IModRegistry registry)
+        {
+            this.api = registry.GetApi<ICustomKissingModApi>("Digus.CustomKissingMod");
+        }
+        public bool CanKissNpc(Farmer who, NPC npc)
+        {
+            if (this.api != null)
+            {
+                return this.api.CanKissNpc(who, npc);
+            }
+
+            return false;
+        }
+    }
+
+    public interface ICustomKissingModApi
+    {
+        bool CanKissNpc(Farmer who, NPC npc);
+    }
+}

--- a/NpcAdventure/Compatibility/CustomKissingModProxy.cs
+++ b/NpcAdventure/Compatibility/CustomKissingModProxy.cs
@@ -11,11 +11,11 @@ namespace NpcAdventure.Compatibility
     /// <summary>
     /// Proxy to Custom Kissing Mod by Digus for keep compatibility with this mod.
     /// </summary>
-    internal class CustomKissing
+    internal class CustomKissingModProxy : ICustomKissingModApi
     {
         private readonly ICustomKissingModApi api;
 
-        public CustomKissing(IModRegistry registry)
+        public CustomKissingModProxy(IModRegistry registry)
         {
             this.api = registry.GetApi<ICustomKissingModApi>("Digus.CustomKissingMod");
         }
@@ -28,10 +28,21 @@ namespace NpcAdventure.Compatibility
 
             return false;
         }
+
+        public bool HasRequiredFriendshipToKiss(Farmer who, NPC npc)
+        {
+            if (this.api != null)
+            {
+                return this.api.HasRequiredFriendshipToKiss(who, npc);
+            }
+
+            return false;
+        }
     }
 
     public interface ICustomKissingModApi
     {
         bool CanKissNpc(Farmer who, NPC npc);
+        bool HasRequiredFriendshipToKiss(Farmer who, NPC npc);
     }
 }

--- a/NpcAdventure/Compatibility/TPMC.cs
+++ b/NpcAdventure/Compatibility/TPMC.cs
@@ -1,9 +1,4 @@
 ﻿using StardewModdingAPI;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NpcAdventure.Compatibility
 {
@@ -14,11 +9,11 @@ namespace NpcAdventure.Compatibility
     {
         public static TPMC Instance { get; private set; }
 
-        public CustomKissing CustomKissing { get; }
+        public ICustomKissingModApi CustomKissing { get; }
 
         private TPMC(IModRegistry registry)
         {
-            this.CustomKissing = new CustomKissing(registry);
+            this.CustomKissing = new CustomKissingModProxy(registry);
         }
 
         public static void Setup(IModRegistry registry)

--- a/NpcAdventure/Compatibility/TPMC.cs
+++ b/NpcAdventure/Compatibility/TPMC.cs
@@ -1,0 +1,32 @@
+﻿using StardewModdingAPI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NpcAdventure.Compatibility
+{
+    /// <summary>
+    /// Third party mod compatibility gateway
+    /// </summary>
+    internal class TPMC
+    {
+        public static TPMC Instance { get; private set; }
+
+        public CustomKissing CustomKissing { get; }
+
+        private TPMC(IModRegistry registry)
+        {
+            this.CustomKissing = new CustomKissing(registry);
+        }
+
+        public static void Setup(IModRegistry registry)
+        {
+            if (Instance == null)
+            {
+                Instance = new TPMC(registry);
+            }
+        }
+    }
+}

--- a/NpcAdventure/NpcAdventure.csproj
+++ b/NpcAdventure/NpcAdventure.csproj
@@ -99,7 +99,7 @@
     <Compile Include="Buffs\BuffManager.cs" />
     <Compile Include="CompanionManager.cs" />
     <Compile Include="AI\Controller\IController.cs" />
-    <Compile Include="Compatibility\CustomKissing.cs" />
+    <Compile Include="Compatibility\CustomKissingModProxy.cs" />
     <Compile Include="Compatibility\TPMC.cs" />
     <Compile Include="Driver\DialogueDriver.cs" />
     <Compile Include="AI\Controller\FollowController.cs" />

--- a/NpcAdventure/NpcAdventure.csproj
+++ b/NpcAdventure/NpcAdventure.csproj
@@ -99,6 +99,8 @@
     <Compile Include="Buffs\BuffManager.cs" />
     <Compile Include="CompanionManager.cs" />
     <Compile Include="AI\Controller\IController.cs" />
+    <Compile Include="Compatibility\CustomKissing.cs" />
+    <Compile Include="Compatibility\TPMC.cs" />
     <Compile Include="Driver\DialogueDriver.cs" />
     <Compile Include="AI\Controller\FollowController.cs" />
     <Compile Include="Driver\HintDriver.cs" />

--- a/NpcAdventure/NpcAdventureMod.cs
+++ b/NpcAdventure/NpcAdventureMod.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using NpcAdventure.Events;
 using NpcAdventure.Model;
 using NpcAdventure.HUD;
+using NpcAdventure.Compatibility;
 
 namespace NpcAdventure
 {
@@ -64,6 +65,10 @@ namespace NpcAdventure
 
         private void GameLoop_GameLaunched(object sender, GameLaunchedEventArgs e)
         {
+            // Setup third party mod compatibility bridge
+            TPMC.Setup(this.Helper.ModRegistry);
+
+            // Mod's services and drivers
             this.SpecialEvents = new SpecialModEvents();
             this.DialogueDriver = new DialogueDriver(this.Helper.Events);
             this.HintDriver = new HintDriver(this.Helper.Events);
@@ -73,7 +78,7 @@ namespace NpcAdventure
             this.companionManager = new CompanionManager(this.DialogueDriver, this.HintDriver, this.companionHud, this.config, this.Monitor);
             this.StuffDriver.RegisterEvents(this.Helper.Events);
             
-            //Harmony
+            // Harmony
             HarmonyInstance harmony = HarmonyInstance.Create("Purrplingcat.NpcAdventure");
             
             Patches.SpouseReturnHomePatch.Setup(harmony);

--- a/NpcAdventure/Utils/Helper.cs
+++ b/NpcAdventure/Utils/Helper.cs
@@ -8,6 +8,7 @@ using StardewValley.Monsters;
 using xTile.Dimensions;
 using System.Diagnostics.Contracts;
 using System.IO;
+using NpcAdventure.Compatibility;
 
 namespace NpcAdventure.Utils
 {
@@ -45,17 +46,23 @@ namespace NpcAdventure.Utils
         {
             // Can't request dialogue if giftable object is in farmer's hands or npc has current dialogues
             bool forbidden = (farmer.ActiveObject != null && farmer.ActiveObject.canBeGivenAsGift()) || npc.CurrentDialogue.Count > 0;
+            bool isMarried = IsSpouseMarriedToFarmer(npc, farmer);
+            bool canKiss = isMarried || (bool)TPMC.Instance?.CustomKissing.CanKissNpc(farmer, npc);
 
-            if (!forbidden && IsSpouseMarriedToFarmer(npc, farmer))
+            /*if (!forbidden && isMarried && !SpouseHasBeenKissedToday(npc))
             {
-                // Kiss married spouse first if she/he facing kissable
-                bool kissedToday = SpouseHasBeenKissedToday(npc);
-                forbidden = !kissedToday && npc.FacingDirection == 3 || !kissedToday && npc.FacingDirection == 1;
-            }
+                // Kiss spouse first if she/he facing kissable
+                forbidden = npc.FacingDirection == 3 || npc.FacingDirection == 1;
+            }*/
+
+            // Kiss spouse first if she/he facing kissable                     
+            forbidden |= canKiss && !SpouseHasBeenKissedToday(npc) && (npc.FacingDirection == 3 || npc.FacingDirection == 1);
+            // Check for possibly marriage dialogues to show if farmer is married to this spouse
+            forbidden |= isMarried && npc.shouldSayMarriageDialogue.Value && npc.currentMarriageDialogue.Count > 0;
 
             return !forbidden;
         }
-
+                                          
         public static List<Point> NearPoints(Point p, int distance)
         {
             List<Point> points = new List<Point>();

--- a/NpcAdventure/Utils/Helper.cs
+++ b/NpcAdventure/Utils/Helper.cs
@@ -47,13 +47,7 @@ namespace NpcAdventure.Utils
             // Can't request dialogue if giftable object is in farmer's hands or npc has current dialogues
             bool forbidden = (farmer.ActiveObject != null && farmer.ActiveObject.canBeGivenAsGift()) || npc.CurrentDialogue.Count > 0;
             bool isMarried = IsSpouseMarriedToFarmer(npc, farmer);
-            bool canKiss = isMarried || (bool)TPMC.Instance?.CustomKissing.CanKissNpc(farmer, npc);
-
-            /*if (!forbidden && isMarried && !SpouseHasBeenKissedToday(npc))
-            {
-                // Kiss spouse first if she/he facing kissable
-                forbidden = npc.FacingDirection == 3 || npc.FacingDirection == 1;
-            }*/
+            bool canKiss = isMarried || ((bool)TPMC.Instance?.CustomKissing.CanKissNpc(farmer, npc) && (bool)TPMC.Instance?.CustomKissing.HasRequiredFriendshipToKiss(farmer, npc));
 
             // Kiss spouse first if she/he facing kissable                     
             forbidden |= canKiss && !SpouseHasBeenKissedToday(npc) && (npc.FacingDirection == 3 || npc.FacingDirection == 1);

--- a/NpcAdventure/assets/Dialogue/Abigail.json
+++ b/NpcAdventure/assets/Dialogue/Abigail.json
@@ -4,7 +4,7 @@
   "companionRejectedNight": "Sorry, it's too late to go exploring today.$s",
   "companionDismiss": "Thanks for bringing me with you @, it was exciting.$h#$b#I hope to do it again sometime. See ya.$h",
   "companionDismissAuto": "Hey @, it's getting late and I'm tired.#$b# I'm going to go home now. If you ever need an adventure partner, Goodnight.$h",
-  "companionRecruited": "Can we go to the mines @?$9 I've always wanted to explore them.$6",
+  "companionRecruited": "Can we go to the mines, @?$9#$b#I've always wanted to explore them.$6",
   "companion_Beach_summer": "If I knew we would come here, I would have brought a hat. And applied some sunscreen.$3",
   "companion_Farm": "You are making a good job on the farm. I'm actually glad that you moved here.$h",
   "companion_Farm_Spouse": "Our farm is never boring, you know? Even so, I think we could change a little something here and there.",

--- a/NpcAdventure/manifest.json
+++ b/NpcAdventure/manifest.json
@@ -6,5 +6,12 @@
   "UniqueID": "purrplingcat.npcadventure",
   "EntryDll": "NpcAdventure.dll",
   "MinimumApiVersion": "3.0.0",
-  "UpdateKeys": [ "Nexus:4582" ]
+  "UpdateKeys": [ "Nexus:4582" ],
+  "Dependencies": [
+    {
+      "UniqueID": "Digus.CustomKissingMod",
+      "MinimumVersion": "1.2.0-beta.3",
+      "IsRequired": false
+    }
+  ]
 }

--- a/NpcAdventure/manifest.json
+++ b/NpcAdventure/manifest.json
@@ -10,7 +10,7 @@
   "Dependencies": [
     {
       "UniqueID": "Digus.CustomKissingMod",
-      "MinimumVersion": "1.2.0-beta.3",
+      "MinimumVersion": "1.2.0",
       "IsRequired": false
     }
   ]


### PR DESCRIPTION
Also fixed bug in Abby recruited dialogue

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Content updates (new dialogues added or some string edited and etc)
- [ ] **Merge ASAP**
- [ ] Merge before *enumerated issues or other PRs numbers*
- [ ] Merge after *enumerated issues or other PRs numbers*

## Description
Compatibilize NPC Adventures with custom kissing mod in better way. Also fixed a bug in Abigail's recruited dialogue.

## How to test
Can custom kiss an NPC. When is that NPC kissed, can ask to recruit.

## Checklist

**Please check if the PR fulfills these requirements**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Changes was tested and passed

## Other information

Optionaly dependency on **Custom Kissing Mod**. When this mod is present, it's required version **1.2.0** or newer. With older versions NPC Adventure don't work and can't be loaded!

---
<!-- Related issues, see https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords#about-issue-references
  For example:
    - Closes #1, fixes #2
    - Requires #5
    - Is required for #6
    - ... and some others
-->
