### PR TITLE
Support for dating dialogues

### DIFF
--- a/NpcAdventure/HUD/CompanionDisplay.cs
+++ b/NpcAdventure/HUD/CompanionDisplay.cs
@@ -143,7 +143,7 @@ namespace NpcAdventure.HUD
 
                     skill.UpdatePosition(framePosition, iconPosition);
                     skill.Draw(spriteBatch);
-                    skillSize = position.X + (i * iconGrid) + 5;                   
+                    this.skillSize = position.X + (i * iconGrid) + 5;                   
                 }       
             
         }
@@ -184,7 +184,7 @@ namespace NpcAdventure.HUD
 
         public void DrawKeysHelp(SpriteBatch spriteBatch)
         {
-            float vX = skillSize;
+            float vX = this.skillSize;
             float vY = 37;
 
             if (Constants.TargetPlatform != GamePlatform.Android)

--- a/NpcAdventure/Utils/DialogueHelper.VariousKeyGenerator.cs
+++ b/NpcAdventure/Utils/DialogueHelper.VariousKeyGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using StardewModdingAPI.Utilities;
+using StardewValley;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -39,7 +40,7 @@ namespace NpcAdventure.Utils
             public int[] FriendshipHeartScale { get; private set; }
             public SDate Date { get; set; } = SDate.Now();
             public bool IsNight { get; set; } = false;
-            public bool IsMarried { get; set; } = false;
+            public FriendshipStatus FriendshipStatus { get; set; } = FriendshipStatus.Friendly;
             public string Weather { get; set; }
 
             private void Enhance(string key)
@@ -54,9 +55,12 @@ namespace NpcAdventure.Utils
                 List<string> variants = new List<string>();
                 Tuple<bool, string>[] conditions = 
                 {
-                    new Tuple<bool, string>(this.IsNight && this.IsMarried && this.Weather != null, "_Night_" + this.Weather + "_Spouse"),
-                    new Tuple<bool, string>(this.Weather != null && this.IsMarried, "_" + this.Weather + "_Spouse"),
-                    new Tuple<bool, string>(this.IsMarried, "_Spouse"),
+                    new Tuple<bool, string>(this.IsNight && this.FriendshipStatus == FriendshipStatus.Married && this.Weather != null, "_Night_" + this.Weather + "_Spouse"),
+                    new Tuple<bool, string>(this.Weather != null && this.FriendshipStatus == FriendshipStatus.Married, "_" + this.Weather + "_Spouse"),
+                    new Tuple<bool, string>(this.FriendshipStatus == FriendshipStatus.Married, "_Spouse"),
+                    new Tuple<bool, string>(this.IsNight && this.FriendshipStatus == FriendshipStatus.Dating && this.Weather != null, "_Night_" + this.Weather + "_Dating"),
+                    new Tuple<bool, string>(this.Weather != null && this.FriendshipStatus == FriendshipStatus.Dating, "_" + this.Weather + "_Dating"),
+                    new Tuple<bool, string>(this.FriendshipStatus == FriendshipStatus.Dating, "_Dating"),
                     new Tuple<bool, string>(this.IsNight && this.Weather != null, "_Night_" + this.Weather),
                     new Tuple<bool, string>(this.IsNight, "_Night"),
                     new Tuple<bool, string>(this.Weather != null, "_" + this.Weather),

--- a/NpcAdventure/Utils/DialogueHelper.cs
+++ b/NpcAdventure/Utils/DialogueHelper.cs
@@ -93,7 +93,7 @@ namespace NpcAdventure.Utils
             {
                 Date = SDate.Now(),
                 IsNight = Game1.isDarkOut(),
-                IsMarried = Helper.IsSpouseMarriedToFarmer(n, f),
+                FriendshipStatus = f.friendshipData.TryGetValue(n.Name, out Friendship friendship) ? friendship.Status : FriendshipStatus.Friendly,
                 FriendshipHeartLevel = f.getFriendshipHeartLevelForNPC(n.Name),
                 Weather = Helper.GetCurrentWeatherName(),
             };

--- a/docs/modding/dialogues.md
+++ b/docs/modding/dialogues.md
@@ -154,7 +154,7 @@ Time based dialogues has following format checked in this order:
 
 Dialogues can be conditioned by game state. Conditions are:
 
-- Is player married with this NPC?
+- Is player married or dating with this NPC?
 - Is day or night?
 - Whats is a weather? Rainy? Sunny or something else?
 - and combinations of this conditions
@@ -165,6 +165,9 @@ This keys has a following format and checked in this order:
 *_Night_<weather>_Spouse
 *_<weather>_Spouse
 *_Spouse
+*_Night_<weather>_Dating
+*_<weather>_Dating
+*_Dating
 *_Night_<weather>
 *_Night
 *_<weather>


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Content updates (new dialogues added or some string edited and etc)
- [ ] **Merge ASAP**
- [ ] Merge before *enumerated issues or other PRs numbers*
- [ ] Merge after *enumerated issues or other PRs numbers*

## Description
Adds a support for dating dialogues with `_Dating` suffix.

Renamed `isMarried` flag in Dialogue key generator to `FriendshipStatus` and changed type to `StardewValley.FriendshipStatus` enum.

## How to test
<!-- Write here a test scenario if it's possible -->

## Checklist

**Please check if the PR fulfills these requirements**
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Changes was tested and passed

## Other information
---
<!-- Related issues, see https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords#about-issue-references
  For example:
    - Closes #1, fixes #2
    - Requires #5
    - Is required for #6
    - ... and some others
-->
Closes #112 