### PR TITLE
More safe harmony patching

### DIFF
--- a/NpcAdventure/Internal/Patching/GamePatcher.cs
+++ b/NpcAdventure/Internal/Patching/GamePatcher.cs
@@ -1,0 +1,67 @@
+﻿using Harmony;
+using StardewModdingAPI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NpcAdventure.Internal.Patching
+{
+    internal class GamePatcher
+    {
+        private readonly IMonitor monitor;
+        private readonly bool paranoid;
+        private readonly HarmonyInstance harmony;
+
+        public GamePatcher(IMonitor monitor, bool paranoid = true)
+        {
+            this.monitor = monitor;
+            this.paranoid = paranoid;
+            this.harmony = HarmonyInstance.Create("cz.purrplingcat.npcadventures");
+        }
+
+        public void CheckPatches()
+        {
+            try
+            {
+                var methods = this.harmony.GetPatchedMethods();
+
+                foreach (var method in methods)
+                {
+                    Harmony.Patches info = this.harmony.GetPatchInfo(method);
+
+                    if (info.Owners.Contains(this.harmony.Id) && info.Owners.Count > 1)
+                    {
+                        IEnumerable<string> foreignOwners = info.Owners.Where(owner => owner != this.harmony.Id);
+
+                        this.monitor.Log($"Game method '{method.FullDescription()}' was patched by others too: {string.Join(", ", foreignOwners)}",
+                            this.paranoid ? LogLevel.Warn : LogLevel.Debug);
+                    }
+                }
+            } catch (Exception ex)
+            {
+                this.monitor.Log("Unable to check game patches. See log for more details.", LogLevel.Error);
+                this.monitor.Log(ex.ToString(), LogLevel.Trace);
+            }
+        }
+
+        /// <summary>
+        /// Apply game patches
+        /// </summary>
+        /// <param name="patches"></param>
+        public void Apply(params IPatch[] patches)
+        {
+            foreach (IPatch patch in patches)
+            {
+                try
+                {
+                    patch.Apply(this.harmony, this.monitor);
+                    this.monitor.Log($"Applied runtime patch '{patch.Name}' to the game.");
+                } catch (Exception ex)
+                {
+                    this.monitor.Log($"Couldn't apply runtime patch '{patch.Name}' to the game. Some features may not works correctly. See log file for more details.", LogLevel.Error);
+                    this.monitor.Log(ex.ToString(), LogLevel.Trace);
+                }
+            }
+        }
+    }
+}

--- a/NpcAdventure/Internal/Patching/GamePatcher.cs
+++ b/NpcAdventure/Internal/Patching/GamePatcher.cs
@@ -33,7 +33,7 @@ namespace NpcAdventure.Internal.Patching
                     {
                         IEnumerable<string> foreignOwners = info.Owners.Where(owner => owner != this.harmony.Id);
 
-                        this.monitor.Log($"Game method '{method.FullDescription()}' was patched by others too: {string.Join(", ", foreignOwners)}",
+                        this.monitor.Log($"Detected another patches for game method '{method.FullDescription()}'. This method was patched too by: {string.Join(", ", foreignOwners)}",
                             this.paranoid ? LogLevel.Warn : LogLevel.Debug);
                     }
                 }

--- a/NpcAdventure/Internal/Patching/IPatch.cs
+++ b/NpcAdventure/Internal/Patching/IPatch.cs
@@ -1,0 +1,12 @@
+﻿using Harmony;
+using StardewModdingAPI;
+
+namespace NpcAdventure.Internal.Patching
+{
+    internal interface IPatch
+    {
+        string Name { get; }
+        bool Applied { get; }
+        void Apply(HarmonyInstance harmony, IMonitor monitor);
+    }
+}

--- a/NpcAdventure/NpcAdventure.csproj
+++ b/NpcAdventure/NpcAdventure.csproj
@@ -124,8 +124,11 @@
     <Compile Include="Loader\IContentLoader.cs" />
     <Compile Include="Model\BagDumpInfo.cs" />
     <Compile Include="Model\CompanionMetaData.cs" />
+    <Compile Include="Internal\Patching\GamePatcher.cs" />
     <Compile Include="Patches\GetCharacterPatch.cs" />
+    <Compile Include="Internal\Patching\IPatch.cs" />
     <Compile Include="Patches\NpcCheckActionPatch.cs" />
+    <Compile Include="Patches\Patch.cs" />
     <Compile Include="Patches\QuestPatch.cs" />
     <Compile Include="Internal\SetOnce.cs" />
     <Compile Include="Story\Messaging\GameMasterMessage.cs" />

--- a/NpcAdventure/NpcAdventure.csproj
+++ b/NpcAdventure/NpcAdventure.csproj
@@ -15,6 +15,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
+    <EnableHarmony>true</EnableHarmony>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -72,10 +73,6 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=1.2.0.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Lib.Harmony.1.2.0.1\lib\net45\0Harmony.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="SMAPI.Toolkit.CoreInterfaces, Version=3.0.1.0, Culture=neutral, PublicKeyToken=null">
       <Private>False</Private>
     </Reference>

--- a/NpcAdventure/NpcAdventureMod.cs
+++ b/NpcAdventure/NpcAdventureMod.cs
@@ -2,7 +2,6 @@
 using StardewModdingAPI.Events;
 using NpcAdventure.Loader;
 using NpcAdventure.Driver;
-using Harmony;
 using NpcAdventure.Events;
 using NpcAdventure.Model;
 using NpcAdventure.HUD;

--- a/NpcAdventure/NpcAdventureMod.cs
+++ b/NpcAdventure/NpcAdventureMod.cs
@@ -19,7 +19,6 @@ namespace NpcAdventure
         private HintDriver HintDriver { get; set; }
         private StuffDriver StuffDriver { get; set; }
         private MailDriver MailDriver { get; set; }
-        private GamePatcher Patcher { get; set; }
         internal ISpecialModEvents SpecialEvents { get; private set; }
         internal CompanionManager CompanionManager { get; private set; }
         internal CompanionDisplay CompanionHud { get; private set; }
@@ -37,7 +36,6 @@ namespace NpcAdventure
             }
 
             this.Config = helper.ReadConfig<Config>();
-            this.Patcher = new GamePatcher(this.Monitor, this.Config.EnableDebug);
             this.ContentLoader = new ContentLoader(this.Helper.Content, this.Helper.ContentPacks, this.ModManifest.UniqueID, "assets", this.Monitor);
             this.RegisterEvents(helper.Events);
             Commander.Register(this);
@@ -97,7 +95,9 @@ namespace NpcAdventure
 
         private void ApplyPatches()
         {
-            this.Patcher.Apply(
+            var patcher = new GamePatcher(this.Monitor, this.Config.EnableDebug);
+
+            patcher.Apply(
                 new Patches.MailBoxPatch((SpecialModEvents)this.SpecialEvents),
                 new Patches.QuestPatch((SpecialModEvents)this.SpecialEvents),
                 new Patches.SpouseReturnHomePatch(this.CompanionManager),
@@ -106,7 +106,9 @@ namespace NpcAdventure
                 new Patches.CompanionSayHiPatch(this.CompanionManager),
                 new Patches.GameLocationDrawPatch((SpecialModEvents)this.SpecialEvents)
             );
-            this.Patcher.CheckPatches();
+
+            // Check if methods patched by NA are patched by other mods
+            patcher.CheckPatches();
         }
 
         private void Specialized_LoadStageChanged(object sender, LoadStageChangedEventArgs e)

--- a/NpcAdventure/Patches/CompanionSayHiPatch.cs
+++ b/NpcAdventure/Patches/CompanionSayHiPatch.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework.Graphics;
 using NpcAdventure.Events;
 using NpcAdventure.Internal;
 using NpcAdventure.StateMachine;
+using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Monsters;
 using System;
@@ -14,26 +15,39 @@ using static NpcAdventure.StateMachine.CompanionStateMachine;
 
 namespace NpcAdventure.Patches
 {
-    internal class CompanionSayHiPatch
+    internal class CompanionSayHiPatch : Patch<CompanionSayHiPatch>
     {
-        private static readonly SetOnce<CompanionManager> manager = new SetOnce<CompanionManager>();
-        private static CompanionManager Manager { get => manager.Value; set => manager.Value = value; }
+        private CompanionManager Manager { get; set; }
+
+        public override string Name => nameof(CompanionSayHiPatch);
+
+        public CompanionSayHiPatch(CompanionManager manager)
+        {
+            this.Manager = manager;
+            Instance = this;
+        }
 
         internal static bool Before_sayHiTo(ref NPC __instance, Character c)
         {
-            if (Manager != null && Manager.PossibleCompanions.TryGetValue(__instance.Name, out CompanionStateMachine csm))
+            try
             {
-                // Avoid say hi to monsters while companion is recruited
-                return !(csm.CurrentStateFlag == StateFlag.RECRUITED && c is Monster);
-            }
+                if (Instance.Manager != null && Instance.Manager.PossibleCompanions.TryGetValue(__instance.Name, out CompanionStateMachine csm))
+                {
+                    // Avoid say hi to monsters while companion is recruited
+                    return !(csm.CurrentStateFlag == StateFlag.RECRUITED && c is Monster);
+                }
 
-            return true;
+                return true;
+            } 
+            catch (Exception ex)
+            {
+                Instance.LogFailure(ex, nameof(Before_sayHiTo));
+                return true;
+            }
         }
 
-        internal static void Setup(HarmonyInstance harmony, CompanionManager manager)
+        protected override void Apply(HarmonyInstance harmony)
         {
-            Manager = manager;
-
             harmony.Patch(
                 original: AccessTools.Method(typeof(NPC), nameof(NPC.sayHiTo)),
                 prefix: new HarmonyMethod(typeof(CompanionSayHiPatch), nameof(CompanionSayHiPatch.Before_sayHiTo))

--- a/NpcAdventure/Patches/NpcCheckActionPatch.cs
+++ b/NpcAdventure/Patches/NpcCheckActionPatch.cs
@@ -1,54 +1,68 @@
 ﻿using Harmony;
 using NpcAdventure.Compatibility;
-using NpcAdventure.Internal;
 using StardewValley;
 using System;
-using static NpcAdventure.StateMachine.CompanionStateMachine;
 
 namespace NpcAdventure.Patches
 {
-    internal class NpcCheckActionPatch
+    internal class NpcCheckActionPatch : Patch<NpcCheckActionPatch>
     {
-        private static readonly SetOnce<CompanionManager> manager = new SetOnce<CompanionManager>();
-        private static CompanionManager Manager { get => manager.Value; set => manager.Value = value; }
+        private CompanionManager Manager { get; set; }
+        public override string Name => nameof(NpcCheckActionPatch);
 
-        internal static void Before_checkAction(NPC __instance, ref bool __state, Farmer who)
+        public NpcCheckActionPatch(CompanionManager manager)
         {
-            bool canKiss = (bool)TPMC.Instance?.CustomKissing.CanKissNpc(who, __instance) && (bool)TPMC.Instance?.CustomKissing.HasRequiredFriendshipToKiss(who, __instance);
-            bool recruited = Manager.PossibleCompanions.TryGetValue(__instance.Name, out var csm) && csm.CurrentStateFlag == StateFlag.RECRUITED;
+            this.Manager = manager;
+            Instance = this;
+        }
 
-            // Save has been kissed flag to state for use in postfix (we want to know previous has kissed state before kiss)
-            // Mark as kissed when we can't kiss them (cover angry emote when try to kiss - vanilla and custom kissing mod)
-            __state = __instance.hasBeenKissedToday || !canKiss;
+        private static void Before_checkAction(NPC __instance, ref bool __state, Farmer who)
+        {
+            try
+            {
+                bool canKiss = (bool)TPMC.Instance?.CustomKissing.CanKissNpc(who, __instance) && (bool)TPMC.Instance?.CustomKissing.HasRequiredFriendshipToKiss(who, __instance);
+
+                // Save has been kissed flag to state for use in postfix (we want to know previous has kissed state before kiss)
+                // Mark as kissed when we can't kiss them (cover angry emote when try to kiss - vanilla and custom kissing mod)
+                __state = __instance.hasBeenKissedToday || !canKiss;
+            } catch (Exception ex)
+            {
+                Instance.LogFailure(ex, nameof(Before_checkAction));
+                __state = false; // Fallback: Mark NPC as NOT kissed today for after patch
+            }
         }
 
         [HarmonyPriority(-1000)]
         [HarmonyAfter("Digus.CustomKissingMod")]
-        internal static void After_checkAction(ref NPC __instance, ref bool __result, bool __state, Farmer who, GameLocation l)
+        private static void After_checkAction(ref NPC __instance, ref bool __result, bool __state, Farmer who, GameLocation l)
         {
-            if (__instance.CurrentDialogue.Count > 0)
-                return;
-
-            // Check our action when vanilla check action don't triggered or spouse was kissed today and farmer try to kiss again
-            if (!__result || (__result && __state && who.FarmerSprite.CurrentFrame == 101))
+            try
             {
-                __result = Manager.CheckAction(who, __instance, l);
+                if (__instance.CurrentDialogue.Count > 0)
+                    return;
 
-                // Cancel kiss when spouse was kissed today and we did our action
-                if (__result && who.FarmerSprite.CurrentFrame == 101)
+                // Check our action when vanilla check action don't triggered or spouse was kissed today and farmer try to kiss again
+                if (!__result || (__result && __state && who.FarmerSprite.CurrentFrame == 101))
                 {
-                    who.completelyStopAnimatingOrDoingAction();
-                    __instance.IsEmoting = false;
-                    __instance.Halt();
-                    __instance.facePlayer(who);
+                    __result = Instance.Manager.CheckAction(who, __instance, l);
+
+                    // Cancel kiss when spouse was kissed today and we did our action
+                    if (__result && who.FarmerSprite.CurrentFrame == 101)
+                    {
+                        who.completelyStopAnimatingOrDoingAction();
+                        __instance.IsEmoting = false;
+                        __instance.Halt();
+                        __instance.facePlayer(who);
+                    }
                 }
+            } catch (Exception ex)
+            {
+                Instance.LogFailure(ex, nameof(After_checkAction));
             }
         }
 
-        internal static void Setup(HarmonyInstance harmony, CompanionManager manager)
+        protected override void Apply(HarmonyInstance harmony)
         {
-            Manager = manager;
-
             harmony.Patch(
                 original: AccessTools.Method(typeof(NPC), nameof(NPC.checkAction)),
                 prefix: new HarmonyMethod(typeof(NpcCheckActionPatch), nameof(NpcCheckActionPatch.Before_checkAction)),

--- a/NpcAdventure/Patches/Patch.cs
+++ b/NpcAdventure/Patches/Patch.cs
@@ -1,0 +1,52 @@
+﻿using Harmony;
+using NpcAdventure.Internal;
+using NpcAdventure.Internal.Patching;
+using StardewModdingAPI;
+using System;
+
+namespace NpcAdventure.Patches
+{
+    internal abstract class Patch<T> : IPatch where T : IPatch
+    {
+        private static SetOnce<T> instance = new SetOnce<T>();
+
+        /// <summary>
+        /// Reference to an internal game patch instance
+        /// </summary>
+        /// <exception cref="InvalidOperationException"></exception>
+        protected static T Instance { get => instance.Value; set => instance.Value = value; }
+        protected IMonitor Monitor { get; set; }
+        public abstract string Name { get; }
+        public bool Applied { get; private set; }
+
+        protected abstract void Apply(HarmonyInstance harmony);
+
+        /// <summary>
+        /// Setup and apply game patch
+        /// </summary>
+        /// <param name="harmony"></param>
+        /// <param name="monitor"></param>
+        /// <exception cref="Exception">Any exception raised while appling game patch</exception>
+        public void Apply(HarmonyInstance harmony, IMonitor monitor)
+        {
+            if (Instance == null)
+            {
+                throw new InvalidOperationException($"Cannot apply patch '{this.Name}' without static reference to itself!");
+            }
+
+            if (this.Applied || Instance.Applied)
+            {
+                throw new InvalidOperationException($"Patch '{this.Name}' is already applied!");
+            }
+
+            this.Monitor = monitor;
+            this.Apply(harmony);
+            this.Applied = true; // Set applied flag
+        }
+
+        protected void LogFailure(Exception ex, string patchMethodName)
+        {
+            this.Monitor.Log($"Failed in game patch {this.Name}.{patchMethodName}:\n{ex}", LogLevel.Error);
+        }
+    }
+}

--- a/NpcAdventure/Patches/SpouseReturnHomePatch.cs
+++ b/NpcAdventure/Patches/SpouseReturnHomePatch.cs
@@ -2,25 +2,37 @@
 using NpcAdventure.Internal;
 using NpcAdventure.StateMachine;
 using StardewValley;
+using System;
 using static NpcAdventure.StateMachine.CompanionStateMachine;
 
 namespace NpcAdventure.Patches
 {
-    internal class SpouseReturnHomePatch
+    internal class SpouseReturnHomePatch : Patch<SpouseReturnHomePatch>
     {
-        private static readonly SetOnce<CompanionManager> manager = new SetOnce<CompanionManager>();
-        private static CompanionManager Manager { get => manager.Value; set => manager.Value = value; }
+        private CompanionManager Manager { get; set; }
+        public override string Name => nameof(SpouseReturnHomePatch);
 
-        internal static bool Before_ReturnHomeFromFarmPosition(ref NPC __instance)
+        public SpouseReturnHomePatch(CompanionManager manager)
         {
-            // Ignore home return when married spouse is recruited
-            return !(Manager.PossibleCompanions.TryGetValue(__instance.Name, out CompanionStateMachine csm) && csm.CurrentStateFlag == StateFlag.RECRUITED);
+            this.Manager = manager;
+            Instance = this;
         }
 
-        internal static void Setup(HarmonyInstance harmony, CompanionManager manager)
+        private static bool Before_ReturnHomeFromFarmPosition(ref NPC __instance)
         {
-            Manager = manager;
+            try
+            {
+                // Ignore home return when married spouse is recruited
+                return !(Instance.Manager.PossibleCompanions.TryGetValue(__instance.Name, out CompanionStateMachine csm) && csm.CurrentStateFlag == StateFlag.RECRUITED);
+            } catch (Exception ex)
+            {
+                Instance.LogFailure(ex, nameof(Before_ReturnHomeFromFarmPosition));
+                return true;
+            }
+        }
 
+        protected override void Apply(HarmonyInstance harmony)
+        {
             harmony.Patch(
                 original: AccessTools.Method(typeof(NPC), nameof(NPC.returnHomeFromFarmPosition)),
                 prefix: new HarmonyMethod(typeof(SpouseReturnHomePatch), nameof(SpouseReturnHomePatch.Before_ReturnHomeFromFarmPosition))


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Content updates (new dialogues added or some string edited and etc)
- [ ] **Merge ASAP**
- [ ] Merge before *enumerated issues or other PRs numbers*
- [ ] Merge after *enumerated issues or other PRs numbers*

## Description
Game patching is more safe, rewritten game patch apply method. Also added information log when methods which are patched by NA are patched by other mods too (if debug mode enabled, then message will be logged as paranoid WARNING, otherwise as DEBUG level).

This change may solves a weird game patching stacktraces and when something was wrong while execute patched method and applied patch, got more descriptive error and stacktrace.

## How to test
Whole mod works okay, no errors around game patching in log.

## Checklist

**Please check if the PR fulfills these requirements**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Changes was tested and passed

## Other information
---
<!-- Related issues, see https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords#about-issue-references
  For example:
    - Closes #1, fixes #2
    - Requires #5
    - Is required for #6
    - ... and some others
-->
