### PR TITLE
Scared companion skill + some stuff

### DIFF
--- a/NpcAdventure/AI/AI_StateMachine.cs
+++ b/NpcAdventure/AI/AI_StateMachine.cs
@@ -126,7 +126,9 @@ namespace NpcAdventure.AI
 
         private bool IsThereAnyMonster(float distance = MONSTER_DISTANCE)
         {
-            return Helper.GetNearestMonsterToCharacter(this.npc, distance) != null;
+            Monster monster = Helper.GetNearestMonsterToCharacter(this.npc, distance);
+
+            return monster != null && Helper.IsValidMonster(monster);
         }
 
         private bool PlayerIsNear()

--- a/NpcAdventure/AI/AI_StateMachine.cs
+++ b/NpcAdventure/AI/AI_StateMachine.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
 using NpcAdventure.AI.Controller;
 using NpcAdventure.HUD;
+using NpcAdventure.Internal;
 using NpcAdventure.Loader;
 using NpcAdventure.Model;
 using NpcAdventure.StateMachine;
@@ -31,6 +32,9 @@ namespace NpcAdventure.AI
         }
 
         private const float MONSTER_DISTANCE = 9f;
+        private const string FORAGING_COOLDOWN = "foragingCooldown";
+        private const string CHANGE_STATE_COOLDOWN = "changeStateCooldown";
+        private const string SCARED_COOLDOWN = "scaredCooldown";
         public readonly NPC npc;
         public readonly Farmer player;
         private readonly CompanionDisplay hud;
@@ -39,9 +43,7 @@ namespace NpcAdventure.AI
 
         private readonly IContentLoader loader;
         private Dictionary<State, IController> controllers;
-        private int changeStateCooldown = 0;
-        private int foragingCooldown = 0;
-        private int scaredCooldown = 0;
+        private Countdown cooldown = new Countdown();
 
         internal AI_StateMachine(CompanionStateMachine csm, CompanionDisplay hud, IModEvents events, IMonitor monitor)
         {
@@ -78,7 +80,7 @@ namespace NpcAdventure.AI
             this.ChangeState(State.FOLLOW);
 
             // Do not forage immediatelly after recruit
-            this.foragingCooldown = 500;
+            this.cooldown.Set(FORAGING_COOLDOWN, 500);
 
             this.events.GameLoop.TimeChanged += this.GameLoop_TimeChanged;
         }
@@ -135,8 +137,8 @@ namespace NpcAdventure.AI
         private bool CanForage()
         {
             return this.PlayerIsNear() 
-                && this.changeStateCooldown <= 0
-                && this.foragingCooldown <= 0
+                && !this.cooldown.IsRunning(CHANGE_STATE_COOLDOWN)
+                && !this.cooldown.IsRunning(FORAGING_COOLDOWN)
                 && this.controllers[State.FORAGE] is ForageController fc 
                 && fc.CanForage() 
                 && Game1.random.Next(1, 6) == 1;
@@ -144,7 +146,11 @@ namespace NpcAdventure.AI
 
         private void CheckPotentialStateChange()
         {
-            if (this.Csm.HasSkillsAny("fighter", "warrior") && this.changeStateCooldown == 0 && this.CurrentState != State.FIGHT && this.PlayerIsNear() && this.IsThereAnyMonster())
+            if (this.Csm.HasSkillsAny("fighter", "warrior")
+                && !this.cooldown.IsRunning(CHANGE_STATE_COOLDOWN)
+                && this.CurrentState != State.FIGHT
+                && this.PlayerIsNear()
+                && this.IsThereAnyMonster())
             {
                 this.ChangeState(State.FIGHT);
                 this.Monitor.Log("A 50ft monster is here!");
@@ -152,19 +158,19 @@ namespace NpcAdventure.AI
 
             if (this.CurrentState != State.FOLLOW && this.CurrentController.IsIdle)
             {
-                this.changeStateCooldown = 100;
+                this.cooldown.Set(CHANGE_STATE_COOLDOWN, 100);
                 this.ChangeState(State.FOLLOW);
             }
 
             if (this.Csm.HasSkill("forager") && this.FollowOrIdle() && this.CanForage())
             {
-                this.foragingCooldown = Game1.random.Next(500, 2000);
+                this.cooldown.Set(FORAGING_COOLDOWN, Game1.random.Next(500, 2000));
                 this.ChangeState(State.FORAGE);
             }
 
             if (this.CurrentState == State.FOLLOW && this.CurrentController.IsIdle)
             {
-                this.foragingCooldown += Game1.random.Next(300, 700);
+                this.cooldown.Increase(FORAGING_COOLDOWN, Game1.random.Next(300, 700));
                 this.ChangeState(State.IDLE);
             }
         }
@@ -182,14 +188,7 @@ namespace NpcAdventure.AI
                 this.CheckPotentialStateChange();
             }
 
-            if (this.changeStateCooldown > 0)
-                --this.changeStateCooldown;
-
-            if (this.foragingCooldown > 0)
-                --this.foragingCooldown;
-
-            if (this.scaredCooldown > 0)
-                --this.scaredCooldown;
+            this.cooldown.Update(e);
 
             if (this.Csm.HasSkill("doctor"))
                 this.UpdateDoctor(e);
@@ -204,31 +203,43 @@ namespace NpcAdventure.AI
         private void DoSideEffects()
         {
             // Be scared
-            if (this.Csm.HasSkill("scared") && this.IsThereAnyMonster() && this.scaredCooldown == 0)
+            if (this.Csm.HasSkill("scared")
+                && this.IsThereAnyMonster(4f)
+                && !this.cooldown.IsRunning(SCARED_COOLDOWN)
+                && Game1.random.Next(0, this.GetNotBeScaredChanceIndex()) == 1)
             {
+                this.npc.Halt();
                 this.npc.shake(1000);
-                this.scaredCooldown = 1200;
+                this.npc.jump();
+                this.npc.currentLocation.playSound("batScreech");
 
                 // Scared companion can occassionally cry
-                if (!this.npc.IsEmoting && Game1.random.Next(1, 8) == 1)
+                if (!this.npc.IsEmoting && Game1.random.Next(0, 8) == 1)
                 {
                     this.npc.doEmote(28);
+                    this.player.changeFriendship(-1, this.npc);
                 }
 
-                // Jump and screech only if companion not fighting and by random chance
-                if (this.CurrentState != State.FIGHT && Game1.random.Next(1, 5) == 1)
-                {
-                    this.npc.Halt();
-                    this.npc.jump();
-                    this.npc.currentLocation.playSound("batScreech");
-                    this.changeStateCooldown = 200;
+                this.cooldown.Set(SCARED_COOLDOWN, Game1.random.Next(800, 2400));
+                this.cooldown.Set(CHANGE_STATE_COOLDOWN, 100);
 
-                    if (!this.npc.IsEmoting)
-                    {
-                        this.npc.doEmote(16);
-                    }
+                if (this.CurrentState != State.FOLLOW)
+                {
+                    this.ChangeState(State.FOLLOW);
                 }
             }
+        }
+
+        private int GetNotBeScaredChanceIndex()
+        {
+            int notBeScaredChance = 4 + this.player.CombatLevel / 2;
+
+            if (this.Csm.HasSkill("warrior"))
+            {
+                return notBeScaredChance * 2;
+            }
+
+            return notBeScaredChance;
         }
 
         public void ChangeLocation(GameLocation l)
@@ -238,7 +249,7 @@ namespace NpcAdventure.AI
             // Warp NPC to player's location at theirs position
             Helper.WarpTo(this.npc, l, this.player.getTileLocationPoint());
 
-            this.changeStateCooldown = 30;
+            this.cooldown.Set(CHANGE_STATE_COOLDOWN, 30);
 
             // Fire location changed event
             this.OnLocationChanged(previousLocation, this.npc.currentLocation);

--- a/NpcAdventure/AI/AI_StateMachine.doctor.cs
+++ b/NpcAdventure/AI/AI_StateMachine.doctor.cs
@@ -4,8 +4,6 @@ using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace NpcAdventure.AI
 {

--- a/NpcAdventure/AI/Controller/FightController.cs
+++ b/NpcAdventure/AI/Controller/FightController.cs
@@ -142,33 +142,6 @@ namespace NpcAdventure.AI.Controller
         public override bool IsIdle => this.CheckIdleState();
 
         /// <summary>
-        /// Checks if spoted monster is a valid monster
-        /// </summary>
-        /// <param name="monster"></param>
-        /// <returns></returns>
-        private bool IsValidMonster(Monster monster)
-        {
-            // Invisible monsters are invalid
-            if (monster.IsInvisible)
-                return false;
-
-            // Only moving rock crab is valid
-            if (monster is RockCrab crab)
-                return crab.isMoving();
-
-            // Only unarmored bug is valid
-            if (monster is Bug bug)
-                return !bug.isArmoredBug.Value;
-
-            // Only live mummy is valid
-            if (monster is Mummy mummy)
-                return mummy.reviveTimer.Value <= 0;
-
-            // All other monsters all valid
-            return true;
-        }
-
-        /// <summary>
         /// Check if is here any monster to fight
         /// </summary>
         private void CheckMonsterToFight()
@@ -176,7 +149,7 @@ namespace NpcAdventure.AI.Controller
             float defendRadius = this.ai.Csm.HasSkill("warrior") ? DEFEND_TILE_RADIUS_WARRIOR : DEFEND_TILE_RADIUS;
             Monster monster = Helper.GetNearestMonsterToCharacter(this.follower, defendRadius);
 
-            if (monster == null || !this.IsValidMonster(monster))
+            if (monster == null || !Helper.IsValidMonster(monster))
             {
                 this.potentialIdle = true;
                 this.leader = null;
@@ -233,7 +206,7 @@ namespace NpcAdventure.AI.Controller
                 return true;
 
             // Go iddle instantly when potential monster is not valid
-            if (this.leader is Monster && !this.IsValidMonster(this.leader as Monster))
+            if (this.leader is Monster && !Helper.IsValidMonster(this.leader as Monster))
                 return true;
 
             return this.potentialIdle; // By default propagate potential iddle state as iddle state

--- a/NpcAdventure/HUD/CompanionDisplay.cs
+++ b/NpcAdventure/HUD/CompanionDisplay.cs
@@ -123,13 +123,13 @@ namespace NpcAdventure.HUD
                     float xOffset = 50;
                     float iconOffset = 16;
                     float iconGrid = 68;
-                    float xIP = position.X - xOffset + iconOffset + (i * iconGrid);
-                    float xFP = position.X - xOffset + (i * iconGrid);
+                    float xIP = position.X - xOffset + iconOffset + (10 - skill.Rectangle.Width) + (i * iconGrid);
+                    float xFP = position.X - xOffset + (10 - skill.Rectangle.Height) + (i * iconGrid);
 
                     if (Constants.TargetPlatform != GamePlatform.Android)
                     {
-                        xIP = position.X - xOffset + iconOffset - (i * iconGrid);
-                        xFP = position.X - xOffset - (i * iconGrid);
+                        xIP = position.X - xOffset + iconOffset + (10 - skill.Rectangle.Width) - (i * iconGrid);
+                        xFP = position.X - xOffset + (10 - skill.Rectangle.Height) - (i * iconGrid);
                     }
 
                     Vector2 iconPosition = new Vector2(xIP, position.Y);

--- a/NpcAdventure/HUD/CompanionSkill.cs
+++ b/NpcAdventure/HUD/CompanionSkill.cs
@@ -32,6 +32,9 @@ namespace NpcAdventure.HUD
                 case "forager":
                     this.icon = new Rectangle(60, 428, 10, 10);
                     break;
+                case "scared":
+                    this.icon = new Rectangle(372, 362, 8, 9);
+                    break;
             }
         }
 
@@ -40,6 +43,8 @@ namespace NpcAdventure.HUD
         public bool ShowTooltip { get; private set; }
         public string HoverText { get; set; }
         public bool Glowing { get => this.ticks > 0; }
+
+        public Rectangle Rectangle { get => this.icon; }
 
         public void Draw(SpriteBatch spriteBatch)
         {

--- a/NpcAdventure/Internal/Countdown.cs
+++ b/NpcAdventure/Internal/Countdown.cs
@@ -1,0 +1,80 @@
+﻿using StardewModdingAPI.Events;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NpcAdventure.Internal
+{
+    internal class Countdown : IUpdateable
+    {
+        private class CountdownTimer
+        {
+            public string name;
+            public int interval;
+
+            public CountdownTimer(string name, int interval)
+            {
+                this.name = name;
+                this.interval = interval;
+            }
+        }
+        private List<CountdownTimer> cooldowns = new List<CountdownTimer>();
+
+        public void Set(string name, int interval)
+        {
+            CountdownTimer timer = this.cooldowns.Find(t => t.name == name);
+
+            if (timer != null)
+            {
+                timer.interval = interval;
+                return;
+            }
+
+            this.cooldowns.Add(new CountdownTimer(name, interval));
+        }
+
+        public void Increase(string name, int amount)
+        {
+            CountdownTimer timer = this.cooldowns.Find(t => t.name == name);
+
+            if (timer != null)
+            {
+                timer.interval += amount;
+                return;
+            }
+
+            this.Set(name, amount);
+        }
+
+        public bool IsRunning(string name)
+        {
+            CountdownTimer timer = this.cooldowns.Find(t => t.name == name);
+
+            return timer != null && timer.interval > 0;
+        }
+
+        public void Reset()
+        {
+            this.cooldowns.Clear();
+        }
+
+        public void Update(UpdateTickedEventArgs e)
+        {
+            if (this.cooldowns.Count <= 0)
+            {
+                return;
+            }
+
+            for (int i = 0; i < this.cooldowns.Count; i++)
+            {
+                if (--this.cooldowns[i].interval <= 0)
+                {
+                    this.cooldowns.RemoveAt(i);
+                    i--;
+                }
+            }
+        }
+    }
+}

--- a/NpcAdventure/NpcAdventure.csproj
+++ b/NpcAdventure/NpcAdventure.csproj
@@ -111,6 +111,7 @@
     <Compile Include="HUD\CompanionDisplay.cs" />
     <Compile Include="HUD\CompanionSkill.cs" />
     <Compile Include="Internal\CompanionDialogue.cs" />
+    <Compile Include="Internal\Countdown.cs" />
     <Compile Include="Internal\IDrawable.cs" />
     <Compile Include="Loader\ContentPacks\AssetPatch.cs" />
     <Compile Include="Loader\AssetsManager.cs" />

--- a/NpcAdventure/Utils/Helper.cs
+++ b/NpcAdventure/Utils/Helper.cs
@@ -177,9 +177,7 @@ namespace NpcAdventure.Utils
 
             foreach (Character c in me.currentLocation.characters)
             {
-                Monster monster = c as Monster;
-
-                if (monster == null)
+                if (!(c is Monster monster))
                     continue;
 
                 float monsterDistance = Helper.Distance(me.getTileLocationPoint(), monster.getTileLocationPoint());
@@ -194,6 +192,33 @@ namespace NpcAdventure.Utils
                 return nearestMonsters.Values.First();
 
             return null;
+        }
+
+        /// <summary>
+        /// Checks if spoted monster is a valid monster
+        /// </summary>
+        /// <param name="monster"></param>
+        /// <returns></returns>
+        public static bool IsValidMonster(Monster monster)
+        {
+            // Invisible monsters are invalid
+            if (monster.IsInvisible)
+                return false;
+
+            // Only moving rock crab is valid
+            if (monster is RockCrab crab)
+                return crab.isMoving();
+
+            // Only unarmored bug is valid
+            if (monster is Bug bug)
+                return !bug.isArmoredBug.Value;
+
+            // Only live mummy is valid
+            if (monster is Mummy mummy)
+                return mummy.reviveTimer.Value <= 0;
+
+            // All other monsters all valid
+            return true;
         }
 
         public static string[] GetSegments(string path, int? limit = null)

--- a/NpcAdventure/assets/Data/CompanionDispositions.json
+++ b/NpcAdventure/assets/Data/CompanionDispositions.json
@@ -3,7 +3,7 @@
   "Maru": "recruitable/doctor fighter//5/0/36",
   "Shane": "recruitable/fighter//5/0/-1",
   "Leah": "recruitable/forager fighter//5/0/39",
-  "Haley": "recruitable/fighter//5/0/42",
+  "Haley": "recruitable/fighter scared//5/0/42",
   "Emily": "recruitable/fighter//5/0/0",
   "Penny": "recruitable/fighter//5/0/38",
   "Alex": "recruitable/warrior//5/0/25",

--- a/NpcAdventure/assets/Strings/Strings.json
+++ b/NpcAdventure/assets/Strings/Strings.json
@@ -17,7 +17,7 @@
   "skill.forager": "Forager ({0}'s skill)",
   "skillDescription.forager": "Will forage while recruited, and can share found forage items with you when you talk to them.",
   "skill.scared": "Scared ({0}'s skill)",
-  "skillDescription.scared": "Occasionally screetches and jump away when see a monster.",
+  "skillDescription.scared": "Occasionally screeches and jumps away when they see a monster.",
   "recruitedCompanionHint": "Companion: {0}",
   "companionState_follow": "Status: Follow",
   "companionState_idle": "Status: Idle",

--- a/NpcAdventure/assets/Strings/Strings.json
+++ b/NpcAdventure/assets/Strings/Strings.json
@@ -16,6 +16,8 @@
   "skillDescription.fighter": "Can fight with a sword.",
   "skill.forager": "Forager ({0}'s skill)",
   "skillDescription.forager": "Will forage while recruited, and can share found forage items with you when you talk to them.",
+  "skill.scared": "Scared ({0}'s skill)",
+  "skillDescription.scared": "Occasionally screetches and jump away when see a monster.",
   "recruitedCompanionHint": "Companion: {0}",
   "companionState_follow": "Status: Follow",
   "companionState_idle": "Status: Idle",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## Upcoming release
 
+- Fighter and Warrior checks only valid monsters around to switch a fight mode
 - Added debug command `npcadventure_recruit` for instant recruit a companion (only for singleplayer or server and for DEBUG PURPOSES ONLY!)
 - Fighters and Warriors withdraw when target lost
 - Refactored cooldown managing

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,8 +2,12 @@
 
 ## Upcoming release
 
-- Leah got forager skill
-- Added forager skill (Companions can forage)
+- Added debug command `npcadventure_recruit` for instant recruit a companion (only for singleplayer or server and for DEBUG PURPOSES ONLY!)
+- Fighters and Warriors withdraw when target lost
+- Refactored cooldown managing
+- Added `scared` skill (this companion occasionally screeches when they see a monster and jump away)
+- Leah got `forager` skill
+- Added `forager` skill (Companions can forage)
 - Mod attempts to detect potential conflicting patches and inform player in the log (in debug mode as warning, otherwise as info level log)
 - Mod uses internal harmony lib in SMAPI (remove 0harmony.dll from the mod folder when upgrading)
 - Harmony patching is now more safer (Hope this can help to solve problems with harmony patches on Linux/Mac)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Content updates (new dialogues added or some string edited and etc)
- [ ] **Merge ASAP**
- [ ] Merge before *enumerated issues or other PRs numbers*
- [ ] Merge after *enumerated issues or other PRs numbers*

## Description

- Added debug command `npcadventure_recruit` for instant recruit a companion (only for singleplayer or server and for DEBUG PURPOSES ONLY!)
- Fighters and Warriors withdraw when target lost
- Refactored cooldown managing
- Added `scared` skill (this companion occasionally screeches when they see a monster and jump away)

For testing purposes assigned Haley to scared skill.

### Missing

- ~~A description and title of scared skill in HUD.~~

## How to test
- Debug command for recruit successfully recruit a companion (debug mode must by enabled)
- All cooldowns still running and has no negative effect on game
- Companion with scared skill occasionally screeetch and jump away (use Haley for test)

## Checklist

**Please check if the PR fulfills these requirements**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Changes was tested and passed

## Other information
---
<!-- Related issues, see https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords#about-issue-references
  For example:
    - Closes #1, fixes #2
    - Requires #5
    - Is required for #6
    - ... and some others
-->

Refs #2 