### PR TITLE
Add priority field for patches in content packs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@
 - Added support for custom weapons for all combat levels (supports JSON assets weapons)
 - Redefined swords for (almost) each companion
 - Tuned fighting behavior
+- Added priority field for patches in content packs (format 1.4)
 
 ## 0.14.1 "Major Minority"
 

--- a/docs/modding/content-packs.md
+++ b/docs/modding/content-packs.md
@@ -38,7 +38,7 @@ In your content pack folder create file `content.json` and we can define custom 
 **<your_cp_folder>/content.json**
 ```js
 {
-  "Format": "1.3",
+  "Format": "1.4",
   "Changes": [
     {
       "Target": "Data/CompanionDispositions",
@@ -65,7 +65,7 @@ Before load content pack assets all base mod's assets are loaded.
 
 | Field                | Required? | Means                                                                                                 |
 | -------------------- | --------- | ----------------------------------------------------------------------------------------------------- |
-| `Format`             | Yes       | The format version. You should always use the latest version (currently 1.3) to use the latest features and avoid obsolete behavior. Old formats could not be supported in current mod version.   |
+| `Format`             | Yes       | The format version. You should always use the latest version (currently 1.4) to use the latest features and avoid obsolete behavior. Old formats could not be supported in current mod version.   |
 | `Changes`            | Yes       | The changes you want to make. Each entry is called a patch, and describes a specific action to perform: Edit json file or load new  |
 
 Under key `Changes` we must define content definitions. It's a list of dicts with these keys:
@@ -77,14 +77,15 @@ Under key `Changes` we must define content definitions. It's a list of dicts wit
 | `Action` (optional)  | No        | The kind of change to make: `Replace` for replace content or load new; `Patch` for patch existing content. Undefined action is implicitly `Patch`. |
 | `LogName` (optional) | No        | This string replaces a default entry #no description in log with custom description                   |
 | `Locale` (optional)  | No        | **Can be used in `Patch` action only!** This key defines a lang code (like `pt-br` and etc), for which this patch can be applied. Use this in pair with the existing content in mod or with existing patch (can be used in pair with action `Replace` patch too). Locale patches are applied only for active game localization for which are defined. |
+| `Priority`           | No        | Priority of this patch. Patches with higher number will be applied later for the target and can rewrite colliding keys in patches with lower priority (lower number)
 
-**NOTE:** If your content pack uses older format (1.2 and older), action, these actions will be automatically rewritten.
+**NOTE:** If your content pack uses legacy format (1.2 and older), action, these actions will be automatically rewritten. Also user must allow loading of legacy packs in config file.
 
 ### Localized content pack patches example
 
 ```js
 {
-  "Format": "1.3",
+  "Format": "1.4",
   "Changes": [
     {
       "Target": "Data/CompanionDispositions",
@@ -118,7 +119,7 @@ Under key `Changes` we must define content definitions. It's a list of dicts wit
 
 ```js
 {
-  "Format": "1.3",
+  "Format": "1.4",
   "Changes": [
     {
       "Target": "Data/CompanionDispositions",

--- a/src/Loader/ContentPacks/Data/ContentChange.cs
+++ b/src/Loader/ContentPacks/Data/ContentChange.cs
@@ -6,13 +6,14 @@ using System.Threading.Tasks;
 
 namespace NpcAdventure.Loader.ContentPacks.Data
 {
-    class LegacyChanges
+    class ContentChange
     {
         public string Action { get; set; }
         public string Target { get; set; }
         public string FromFile { get; set; }
         public string Locale { get; set; }
         public string LogName { get; set; }
+        public int Priority { get; set; }
         public bool Disabled { get; internal set; }
     }
 }

--- a/src/Loader/ContentPacks/Data/Contents.cs
+++ b/src/Loader/ContentPacks/Data/Contents.cs
@@ -13,6 +13,6 @@ namespace NpcAdventure.Loader.ContentPacks.Data
         public List<Dialogues> Dialogues { get; set; }
 
         // Legacy field (formats 1.1 - 1.3)
-        public List<LegacyChanges> Changes { get; set; }
+        public List<ContentChange> Changes { get; set; }
     }
 }

--- a/src/Loader/ContentPacks/ManagedPatch.cs
+++ b/src/Loader/ContentPacks/ManagedPatch.cs
@@ -6,11 +6,12 @@ namespace NpcAdventure.Loader.ContentPacks
 {
     internal class ManagedPatch
     {
-        public LegacyChanges Change { get; }
+        public ContentChange Change { get; }
         public ManagedContentPack Owner { get; }
         public bool Disabled { get => this.Change.Disabled; }
+        public int Priority { get => this.Change.Priority; }
 
-        public ManagedPatch(LegacyChanges change, ManagedContentPack managedContentPack)
+        public ManagedPatch(ContentChange change, ManagedContentPack managedContentPack)
         {
             this.Change = change ?? throw new System.ArgumentNullException(nameof(change));
             this.Owner = managedContentPack ?? throw new System.ArgumentNullException(nameof(managedContentPack));

--- a/src/Loader/ContentPacks/ManagedPatch.cs
+++ b/src/Loader/ContentPacks/ManagedPatch.cs
@@ -1,0 +1,24 @@
+﻿using NpcAdventure.Loader.ContentPacks.Data;
+using System;
+using System.Collections.Generic;
+
+namespace NpcAdventure.Loader.ContentPacks
+{
+    internal class ManagedPatch
+    {
+        public LegacyChanges Change { get; }
+        public ManagedContentPack Owner { get; }
+        public bool Disabled { get => this.Change.Disabled; }
+
+        public ManagedPatch(LegacyChanges change, ManagedContentPack managedContentPack)
+        {
+            this.Change = change ?? throw new System.ArgumentNullException(nameof(change));
+            this.Owner = managedContentPack ?? throw new System.ArgumentNullException(nameof(managedContentPack));
+        }
+
+        public Dictionary<TKey, TValue> LoadData<TKey, TValue>()
+        {
+            return this.Owner.Pack.LoadAsset<Dictionary<TKey, TValue>>(this.Change.FromFile);
+        }
+    }
+}

--- a/src/Loader/ContentPacks/PatchApplier.cs
+++ b/src/Loader/ContentPacks/PatchApplier.cs
@@ -1,0 +1,54 @@
+﻿using StardewModdingAPI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NpcAdventure.Loader.ContentPacks
+{
+    internal class PatchApplier
+    {
+
+        public PatchApplier(IMonitor monitor, bool paranoid)
+        {
+            this.Monitor = monitor;
+            this.paranoid = paranoid;
+        }
+
+        public IMonitor Monitor { get; }
+
+        private readonly bool paranoid;
+
+        public bool Apply<TKey, TValue>(Dictionary<TKey, TValue> target, IEnumerable<ManagedPatch> patches, string targetName)
+        {
+            if (patches.Count() < 1)
+            {
+                return false;
+            }
+
+            string contentPackName;
+            foreach (var patch in patches)
+            {
+                contentPackName = patch.Owner.Pack.Manifest.Name;
+
+                if (patch.Change.Action == "Replace")
+                {
+                    if (target.Count > 0)
+                        this.Monitor.Log(
+                            $"Content pack `{contentPackName}` patch `{patch.Change.LogName}` replaces all contents for `{targetName}`.",
+                            this.paranoid ? LogLevel.Alert : LogLevel.Trace);
+                    target.Clear(); // Load replaces all content
+                }
+
+                var isLocalized = !string.IsNullOrEmpty(patch.Change.Locale);
+                var patchData = patch.LoadData<TKey, TValue>();
+
+                AssetPatchHelper.ApplyPatch(target, patchData);
+                this.Monitor.Log($"Content pack `{contentPackName}` applied{(isLocalized ? $" `{patch.Change.Locale}` translation" : "")} patch `{patch.Change.LogName}` for `{targetName}`");
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Loader/ContentPacks/PatchApplier.cs
+++ b/src/Loader/ContentPacks/PatchApplier.cs
@@ -45,7 +45,7 @@ namespace NpcAdventure.Loader.ContentPacks
                 var patchData = patch.LoadData<TKey, TValue>();
 
                 AssetPatchHelper.ApplyPatch(target, patchData);
-                this.Monitor.Log($"Content pack `{contentPackName}` applied{(isLocalized ? $" `{patch.Change.Locale}` translation" : "")} patch `{patch.Change.LogName}` for `{targetName}`");
+                this.Monitor.Log($"Content pack `{contentPackName}` applied{(isLocalized ? $" `{patch.Change.Locale}` translation" : "")} patch `{patch.Change.LogName}` ({patch.Change.Action} type) for `{targetName}`");
             }
 
             return true;

--- a/src/Loader/ContentPacks/Provider/DataProvider.cs
+++ b/src/Loader/ContentPacks/Provider/DataProvider.cs
@@ -30,13 +30,13 @@ namespace NpcAdventure.Loader.ContentPacks.Provider
 
         private Dictionary<TKey, TValue> ResolveDataContents<TKey, TValue>(string subPath)
         {
-            switch (subPath)
+            /*switch (subPath)
             {
                 case "CompanionDispositions":
                     if (this.Managed.Contents.Companions != null)
                         return AsDictionary<TKey, TValue>(this.Managed.Contents.Companions);
                     break;
-            }
+            }*/
 
             return null;
         }

--- a/src/Loader/ContentPacks/Provider/LegacyDataProvider.cs
+++ b/src/Loader/ContentPacks/Provider/LegacyDataProvider.cs
@@ -21,7 +21,7 @@ namespace NpcAdventure.Loader.ContentPacks.Provider
 
         public bool Apply<TKey, TValue>(Dictionary<TKey, TValue> target, string path)
         {
-            var patches = new List<LegacyChanges>();
+            var patches = new List<ManagedPatch>();
             var contentPackName = this.Managed.Pack.Manifest.Name;
 
             patches.AddRange(this.GetPatchesForAsset(path, "Replace"));
@@ -35,38 +35,38 @@ namespace NpcAdventure.Loader.ContentPacks.Provider
 
             foreach (var patch in patches)
             {
-                if (patch.Action == "Replace")
+                if (patch.Change.Action == "Replace")
                 {
                     if (target.Count > 0)
                         this.Monitor.Log(
-                            $"Content pack `{contentPackName}` patch `{patch.LogName}` replaces all contents for `{path}`.", 
+                            $"Content pack `{contentPackName}` patch `{patch.Change.LogName}` replaces all contents for `{path}`.", 
                             this.paranoid ? LogLevel.Alert : LogLevel.Trace);
                     target.Clear(); // Load replaces all content
                 }
 
-                var isLocalized = !string.IsNullOrEmpty(patch.Locale);
-                var patchData = this.Managed.Pack.LoadAsset<Dictionary<TKey, TValue>>(patch.FromFile);
+                var isLocalized = !string.IsNullOrEmpty(patch.Change.Locale);
+                var patchData = patch.LoadData<TKey, TValue>();
                 
                 AssetPatchHelper.ApplyPatch(target, patchData);
-                this.Monitor.Log($"Content pack `{contentPackName}` applied{(isLocalized ? $" `{patch.Locale}` translation" : "")} patch `{patch.LogName}` for `{path}`");
+                this.Monitor.Log($"Content pack `{contentPackName}` applied{(isLocalized ? $" `{patch.Change.Locale}` translation" : "")} patch `{patch.Change.LogName}` for `{path}`");
             }
 
             return true;
         }
 
-        private List<LegacyChanges> GetPatchesForAsset(string path, string action)
+        private List<ManagedPatch> GetPatchesForAsset(string path, string action)
         {
-            return this.Managed.Contents.Changes
-                .Where((p) => p.Action.Equals(action) && p.Target.Equals(path) && !p.Disabled)
-                .Where((p) => string.IsNullOrEmpty(p.Locale))
+            return this.Managed.Patches
+                .Where((p) => p.Change.Action.Equals(action) && p.Change.Target.Equals(path) && !p.Disabled)
+                .Where((p) => string.IsNullOrEmpty(p.Change.Locale))
                 .ToList();
         }
 
-        private List<LegacyChanges> GetTranslationPatches(string path, string locale)
+        private List<ManagedPatch> GetTranslationPatches(string path, string locale)
         {
-            return this.Managed.Contents.Changes
-                .Where((p) => p.Action.Equals("Patch") && p.Target.Equals(path) && !p.Disabled)
-                .Where((p) => !string.IsNullOrEmpty(p.Locale) && p.Locale.ToLower().Equals(locale))
+            return this.Managed.Patches
+                .Where((p) => p.Change.Action.Equals("Patch") && p.Change.Target.Equals(path) && !p.Disabled)
+                .Where((p) => !string.IsNullOrEmpty(p.Change.Locale) && p.Change.Locale.ToLower().Equals(locale))
                 .ToList();
         }
     }


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Content updates (new dialogues added or some string edited and etc)
- [ ] **Merge ASAP**
- [ ] Merge before *enumerated issues or other PRs numbers*
- [ ] Merge after *enumerated issues or other PRs numbers*

## Description
Adds a priority field for patches in content packs

## How to test
<!-- Write here a test scenario if it's possible -->

## Checklist

**Please check if the PR fulfills these requirements**
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] Changes was tested and passed

## Other information
---
<!-- Related issues, see https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords#about-issue-references
  For example:
    - Closes #1, fixes #2
    - Requires #5
    - Is required for #6
    - ... and some others
-->
